### PR TITLE
legend: Fix for vertical alignment issues and provide better defaults

### DIFF
--- a/axis.go
+++ b/axis.go
@@ -127,7 +127,7 @@ func (a *axisPainter) Render() (Box, error) {
 		width = top.Width()
 		height = tickLength<<1 + textMaxHeight
 	}
-	padding := Box{}
+	padding := Box{IsSet: true}
 	switch opt.Position {
 	case PositionTop:
 		padding.Top = top.Height() - height
@@ -220,8 +220,9 @@ func (a *axisPainter) Render() (Box, error) {
 
 	if strokeWidth > 0 {
 		p.Child(PainterPaddingOption(Box{
-			Top:  ticksPaddingTop,
-			Left: ticksPaddingLeft,
+			Top:   ticksPaddingTop,
+			Left:  ticksPaddingLeft,
+			IsSet: true,
 		})).Ticks(TicksOption{
 			LabelCount: labelCount,
 			TickSpaces: tickSpaces,
@@ -239,6 +240,7 @@ func (a *axisPainter) Render() (Box, error) {
 		Left:  labelPaddingLeft,
 		Top:   labelPaddingTop,
 		Right: labelPaddingRight,
+		IsSet: true,
 	})).MultiText(MultiTextOption{
 		First:          opt.DataStartIndex,
 		Align:          textAlign,
@@ -286,5 +288,9 @@ func (a *axisPainter) Render() (Box, error) {
 		}
 	}
 
-	return Box{Bottom: height, Right: width}, nil
+	return Box{
+		Bottom: height,
+		Right:  width,
+		IsSet:  true,
+	}, nil
 }

--- a/chartdraw/box.go
+++ b/chartdraw/box.go
@@ -30,6 +30,46 @@ type Box struct {
 	IsSet  bool
 }
 
+func (b Box) WithTop(val int) Box {
+	return Box{
+		Top:    val,
+		Left:   b.Left,
+		Right:  b.Right,
+		Bottom: b.Bottom,
+		IsSet:  true,
+	}
+}
+
+func (b Box) WithLeft(val int) Box {
+	return Box{
+		Top:    b.Top,
+		Left:   val,
+		Right:  b.Right,
+		Bottom: b.Bottom,
+		IsSet:  true,
+	}
+}
+
+func (b Box) WithRight(val int) Box {
+	return Box{
+		Top:    b.Top,
+		Left:   b.Left,
+		Right:  val,
+		Bottom: b.Bottom,
+		IsSet:  true,
+	}
+}
+
+func (b Box) WithBottom(val int) Box {
+	return Box{
+		Top:    b.Top,
+		Left:   b.Left,
+		Right:  b.Right,
+		Bottom: val,
+		IsSet:  true,
+	}
+}
+
 // IsZero returns if the box is set or not.
 func (b Box) IsZero() bool {
 	if b.IsSet {
@@ -150,6 +190,7 @@ func (b Box) Grow(other Box) Box {
 		Left:   MinInt(b.Left, other.Left),
 		Right:  MaxInt(b.Right, other.Right),
 		Bottom: MaxInt(b.Bottom, other.Bottom),
+		IsSet:  true,
 	}
 }
 
@@ -160,6 +201,7 @@ func (b Box) Shift(x, y int) Box {
 		Left:   b.Left + x,
 		Right:  b.Right + x,
 		Bottom: b.Bottom + y,
+		IsSet:  true,
 	}
 }
 
@@ -199,6 +241,7 @@ func (b Box) Fit(other Box) Box {
 			Left:   b.Left,
 			Right:  b.Right,
 			Bottom: (b.Top + bh2) + noh2,
+			IsSet:  true,
 		}
 	}
 	var now2 int
@@ -212,6 +255,7 @@ func (b Box) Fit(other Box) Box {
 		Left:   (b.Left + bw2) - now2,
 		Right:  (b.Left + bw2) + now2,
 		Bottom: b.Bottom,
+		IsSet:  true,
 	}
 }
 
@@ -282,6 +326,7 @@ func (bc BoxCorners) Box() Box {
 		Left:   MinInt(bc.TopLeft.X, bc.BottomLeft.X),
 		Right:  MaxInt(bc.TopRight.X, bc.BottomRight.X),
 		Bottom: MaxInt(bc.BottomLeft.Y, bc.BottomRight.Y),
+		IsSet:  true,
 	}
 }
 

--- a/chartdraw/legend.go
+++ b/chartdraw/legend.go
@@ -30,6 +30,7 @@ func Legend(c *Chart, userDefaults ...Style) Renderable {
 			Left:   5,
 			Right:  5,
 			Bottom: 5,
+			IsSet:  true,
 		}
 		lineTextGap := 5
 		lineLengthMinimum := 25
@@ -49,6 +50,7 @@ func Legend(c *Chart, userDefaults ...Style) Renderable {
 			Top:  cb.Top,
 			Left: cb.Left,
 			// bottom and right will be sized by the legend content + relevant padding.
+			IsSet: true,
 		}
 
 		legendContent := Box{
@@ -56,6 +58,7 @@ func Legend(c *Chart, userDefaults ...Style) Renderable {
 			Left:   legend.Left + legendPadding.Left,
 			Right:  legend.Left + legendPadding.Left,
 			Bottom: legend.Top + legendPadding.Top,
+			IsSet:  true,
 		}
 
 		legendStyle.GetTextOptions().WriteToRenderer(r)
@@ -136,6 +139,7 @@ func LegendThin(c *Chart, userDefaults ...Style) Renderable {
 				Left:   7,
 				Right:  7,
 				Bottom: 5,
+				IsSet:  true,
 			},
 		}
 
@@ -181,6 +185,7 @@ func LegendThin(c *Chart, userDefaults ...Style) Renderable {
 			Right:  cb.Right,
 			Top:    legendYMargin,
 			Bottom: legendYMargin + legendBoxHeight,
+			IsSet:  true,
 		}
 
 		Draw.Box(r, legendBox, legendDefaults)
@@ -246,6 +251,7 @@ func LegendLeft(c *Chart, userDefaults ...Style) Renderable {
 			Left:   5,
 			Right:  5,
 			Bottom: 5,
+			IsSet:  true,
 		}
 		lineTextGap := 5
 		lineLengthMinimum := 25
@@ -265,6 +271,7 @@ func LegendLeft(c *Chart, userDefaults ...Style) Renderable {
 			Top:  5,
 			Left: 5,
 			// bottom and right will be sized by the legend content + relevant padding.
+			IsSet: true,
 		}
 
 		legendContent := Box{
@@ -272,6 +279,7 @@ func LegendLeft(c *Chart, userDefaults ...Style) Renderable {
 			Left:   legend.Left + legendPadding.Left,
 			Right:  legend.Left + legendPadding.Left,
 			Bottom: legend.Top + legendPadding.Top,
+			IsSet:  true,
 		}
 
 		legendStyle.GetTextOptions().WriteToRenderer(r)

--- a/chartdraw/pie_chart.go
+++ b/chartdraw/pie_chart.go
@@ -108,6 +108,7 @@ func (pc PieChart) drawBackground(r Renderer) {
 	Draw.Box(r, Box{
 		Right:  pc.GetWidth(),
 		Bottom: pc.GetHeight(),
+		IsSet:  true,
 	}, pc.getBackgroundStyle())
 }
 
@@ -196,6 +197,7 @@ func (pc PieChart) getCircleAdjustedCanvasBox(canvasBox Box) Box {
 	square := Box{
 		Right:  circleDiameter,
 		Bottom: circleDiameter,
+		IsSet:  true,
 	}
 
 	return canvasBox.Fit(square)
@@ -305,5 +307,6 @@ func (pc PieChart) Box() Box {
 		Left:   pc.Background.Padding.GetLeft(DefaultBackgroundPadding.Left),
 		Right:  pc.GetWidth() - dpr,
 		Bottom: pc.GetHeight() - dpb,
+		IsSet:  true,
 	}
 }

--- a/chartdraw/raster_renderer.go
+++ b/chartdraw/raster_renderer.go
@@ -195,6 +195,7 @@ func (rr *rasterRenderer) MeasureText(body string) Box {
 		Left:   int(math.Ceil(l)),
 		Right:  int(math.Ceil(r)),
 		Bottom: int(math.Ceil(b)),
+		IsSet:  true,
 	}
 	if rr.rotateRadians == nil {
 		return textBox

--- a/chartdraw/stacked_bar_chart.go
+++ b/chartdraw/stacked_bar_chart.go
@@ -162,6 +162,7 @@ func (sbc StackedBarChart) drawBackground(r Renderer) {
 	Draw.Box(r, Box{
 		Right:  sbc.GetWidth(),
 		Bottom: sbc.GetHeight(),
+		IsSet:  true,
 	}, sbc.getBackgroundStyle())
 }
 
@@ -199,6 +200,7 @@ func (sbc StackedBarChart) drawBar(r Renderer, canvasBox Box, xoffset int, bar S
 			Left:   bxl,
 			Right:  bxr,
 			Bottom: MinInt(yoffset+barHeight, canvasBox.Bottom-DefaultStrokeWidth),
+			IsSet:  true,
 		}
 		Draw.Box(r, barBox, bv.Style.InheritFrom(sbc.styleDefaultsStackedBarValue(index)))
 		yoffset += barHeight
@@ -250,6 +252,7 @@ func (sbc StackedBarChart) drawHorizontalBar(r Renderer, canvasBox Box, yoffset 
 			Left:   MinInt(xOffset-barHeight, canvasBox.Left+DefaultStrokeWidth),
 			Right:  xOffset,
 			Bottom: boxBottom,
+			IsSet:  true,
 		}
 		Draw.Box(r, barBox, bv.Style.InheritFrom(sbc.styleDefaultsStackedBarValue(index)))
 		xOffset -= barHeight
@@ -304,6 +307,7 @@ func (sbc StackedBarChart) drawXAxis(r Renderer, canvasBox Box) {
 				Left:   cursor,
 				Right:  cursor + bar.GetWidth() + sbc.GetBarSpacing(),
 				Bottom: sbc.GetHeight(),
+				IsSet:  true,
 			}
 			if len(bar.Name) > 0 {
 				Draw.TextWithin(r, bar.Name, barLabelBox, axisStyle)
@@ -402,6 +406,7 @@ func (sbc StackedBarChart) drawHorizontalYAxis(r Renderer, canvasBox Box) {
 				Left:   0,
 				Right:  canvasBox.Left - DefaultYAxisMargin,
 				Bottom: cursor + bar.GetWidth() + sbc.GetBarSpacing(),
+				IsSet:  true,
 			}
 			if len(bar.Name) > 0 {
 				Draw.TextWithin(r, bar.Name, barLabelBox, axisStyle)
@@ -478,6 +483,7 @@ func (sbc StackedBarChart) getAdjustedCanvasBox(r Renderer, canvasBox Box) Box {
 					Left:   cursor,
 					Right:  cursor + bar.GetWidth() + sbc.GetBarSpacing(),
 					Bottom: sbc.GetHeight(),
+					IsSet:  true,
 				}
 				lines := Text.WrapFit(r, bar.Name, barLabelBox.Width(), axisStyle)
 				linesBox := Text.MeasureLines(r, lines, axisStyle)
@@ -490,6 +496,7 @@ func (sbc StackedBarChart) getAdjustedCanvasBox(r Renderer, canvasBox Box) Box {
 			Left:   canvasBox.Left,
 			Right:  canvasBox.Left + totalWidth,
 			Bottom: sbc.GetHeight() - xaxisHeight,
+			IsSet:  true,
 		}
 	}
 	return Box{
@@ -497,6 +504,7 @@ func (sbc StackedBarChart) getAdjustedCanvasBox(r Renderer, canvasBox Box) Box {
 		Left:   canvasBox.Left,
 		Right:  canvasBox.Left + totalWidth,
 		Bottom: canvasBox.Bottom,
+		IsSet:  true,
 	}
 }
 
@@ -520,6 +528,7 @@ func (sbc StackedBarChart) getHorizontalAdjustedCanvasBox(r Renderer, canvasBox 
 					Left:   0,
 					Right:  canvasBox.Left + DefaultYAxisMargin,
 					Bottom: cursor + bar.GetWidth() + sbc.GetBarSpacing(),
+					IsSet:  true,
 				}
 				lines := Text.WrapFit(r, bar.Name, barLabelBox.Width(), axisStyle)
 				linesBox := Text.MeasureLines(r, lines, axisStyle)
@@ -532,6 +541,7 @@ func (sbc StackedBarChart) getHorizontalAdjustedCanvasBox(r Renderer, canvasBox 
 			Left:   canvasBox.Left + yAxisWidth,
 			Right:  canvasBox.Right,
 			Bottom: canvasBox.Top + totalHeight,
+			IsSet:  true,
 		}
 	}
 	return Box{
@@ -539,6 +549,7 @@ func (sbc StackedBarChart) getHorizontalAdjustedCanvasBox(r Renderer, canvasBox 
 		Left:   canvasBox.Left,
 		Right:  canvasBox.Right,
 		Bottom: canvasBox.Top + totalHeight,
+		IsSet:  true,
 	}
 }
 
@@ -552,6 +563,7 @@ func (sbc StackedBarChart) Box() Box {
 		Left:   sbc.Background.Padding.GetLeft(20),
 		Right:  sbc.GetWidth() - dpr,
 		Bottom: sbc.GetHeight() - dpb,
+		IsSet:  true,
 	}
 }
 

--- a/chartdraw/yaxis.go
+++ b/chartdraw/yaxis.go
@@ -133,6 +133,7 @@ func (ya YAxis) Measure(r Renderer, canvasBox Box, ra Range, defaults Style, tic
 		Left:   minx,
 		Right:  maxx,
 		Bottom: maxy,
+		IsSet:  true,
 	}
 }
 

--- a/charts.go
+++ b/charts.go
@@ -246,6 +246,7 @@ func defaultRender(p *Painter, opt defaultRenderOption) (*defaultRenderResult, e
 		child := p.Child(PainterPaddingOption(Box{
 			Left:  rangeWidthLeft,
 			Right: rangeWidthRight,
+			IsSet: true,
 		}))
 		var yAxis *axisPainter
 		if index == 0 {
@@ -265,15 +266,17 @@ func defaultRender(p *Painter, opt defaultRenderOption) (*defaultRenderResult, e
 	xAxis := NewBottomXAxis(p.Child(PainterPaddingOption(Box{
 		Left:  rangeWidthLeft,
 		Right: rangeWidthRight,
+		IsSet: true,
 	})), opt.XAxis)
 	if _, err := xAxis.Render(); err != nil {
 		return nil, err
 	}
 
 	result.seriesPainter = p.Child(PainterPaddingOption(Box{
-		Bottom: defaultXAxisHeight,
 		Left:   rangeWidthLeft,
 		Right:  rangeWidthRight,
+		Bottom: defaultXAxisHeight,
+		IsSet:  true,
 	}))
 	return &result, nil
 }

--- a/echarts.go
+++ b/echarts.go
@@ -156,19 +156,9 @@ func (eb *EChartsPadding) UnmarshalJSON(data []byte) error {
 	}
 	switch len(arr) {
 	case 1:
-		eb.Box = chartdraw.Box{
-			Left:   arr[0],
-			Top:    arr[0],
-			Bottom: arr[0],
-			Right:  arr[0],
-		}
+		eb.Box = chartdraw.NewBox(arr[0], arr[0], arr[0], arr[0])
 	case 2:
-		eb.Box = chartdraw.Box{
-			Top:    arr[0],
-			Bottom: arr[0],
-			Left:   arr[1],
-			Right:  arr[1],
-		}
+		eb.Box = chartdraw.NewBox(arr[0], arr[1], arr[1], arr[0])
 	default:
 		result := make([]int, 4)
 		copy(result, arr)
@@ -176,12 +166,7 @@ func (eb *EChartsPadding) UnmarshalJSON(data []byte) error {
 			result[3] = result[1]
 		}
 		// top right, bottom left
-		eb.Box = chartdraw.Box{
-			Top:    result[0],
-			Right:  result[1],
-			Bottom: result[2],
-			Left:   result[3],
-		}
+		eb.Box = chartdraw.NewBox(result[0], result[3], result[1], result[2])
 	}
 	return nil
 }

--- a/echarts_test.go
+++ b/echarts_test.go
@@ -75,6 +75,7 @@ func TestEChartsPadding(t *testing.T) {
 		Top:    1,
 		Right:  1,
 		Bottom: 1,
+		IsSet:  true,
 	}, eb.Box)
 
 	require.NoError(t, eb.UnmarshalJSON([]byte(`[2, 3]`)))
@@ -83,6 +84,7 @@ func TestEChartsPadding(t *testing.T) {
 		Top:    2,
 		Right:  3,
 		Bottom: 2,
+		IsSet:  true,
 	}, eb.Box)
 
 	require.NoError(t, eb.UnmarshalJSON([]byte(`[4, 5, 6]`)))
@@ -91,6 +93,7 @@ func TestEChartsPadding(t *testing.T) {
 		Top:    4,
 		Right:  5,
 		Bottom: 6,
+		IsSet:  true,
 	}, eb.Box)
 
 	require.NoError(t, eb.UnmarshalJSON([]byte(`[4, 5, 6, 7]`)))
@@ -99,6 +102,7 @@ func TestEChartsPadding(t *testing.T) {
 		Top:    4,
 		Right:  5,
 		Bottom: 6,
+		IsSet:  true,
 	}, eb.Box)
 }
 

--- a/examples/line_chart-2/main.go
+++ b/examples/line_chart-2/main.go
@@ -60,10 +60,11 @@ func main() {
 			LabelCount:  10,
 		}),
 		func(opt *charts.ChartOption) {
-			opt.Legend.Left = "680"
-			opt.Legend.Orient = "vertical"
+			opt.Legend.Left = charts.PositionRight
+			opt.Legend.Align = charts.AlignRight
+			opt.Legend.Orient = charts.OrientVertical
 			opt.Legend.FontStyle.FontSize = 6
-			opt.Title.Left = "center"
+			opt.Title.Left = charts.PositionCenter
 			opt.SymbolShow = charts.False()
 			opt.LineStrokeWidth = 1.6
 			opt.ValueFormatter = func(f float64) string {

--- a/horizontal_bar_chart.go
+++ b/horizontal_bar_chart.go
@@ -110,6 +110,7 @@ func (h *horizontalBarChart) render(result *defaultRenderResult, seriesList Seri
 				Left:   0,
 				Right:  right,
 				Bottom: y + barHeight,
+				IsSet:  true,
 			})
 			// if the label does not need to be displayed, return
 			if labelPainter == nil {

--- a/legend.go
+++ b/legend.go
@@ -184,6 +184,7 @@ func (l *legendPainter) Render() (Box, error) {
 				Left:   left,
 				Right:  left + legendWidth,
 				Bottom: top + 1,
+				IsSet:  true,
 			})
 			return left + legendWidth
 		}
@@ -194,6 +195,7 @@ func (l *legendPainter) Render() (Box, error) {
 				Left:   left,
 				Right:  left + legendWidth,
 				Bottom: top + legendHeight + 1,
+				IsSet:  true,
 			})
 			return left + legendWidth
 		}
@@ -248,5 +250,6 @@ func (l *legendPainter) Render() (Box, error) {
 	return Box{
 		Right:  width,
 		Bottom: height + padding.Bottom + padding.Top,
+		IsSet:  true,
 	}, nil
 }

--- a/legend_test.go
+++ b/legend_test.go
@@ -93,6 +93,131 @@ func TestNewLegend(t *testing.T) {
 			},
 			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"></svg>",
 		},
+		{
+			name: "vertical_right_position",
+			render: func(p *Painter) ([]byte, error) {
+				_, err := NewLegendPainter(p, LegendOption{
+					Data:   []string{"One", "Two Word", "Three Word Item", "Four Words Is Longer"},
+					Orient: OrientVertical,
+					Left:   PositionRight,
+				}).Render()
+				if err != nil {
+					return nil, err
+				}
+				return p.Bytes()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 421 9\nL 451 9\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><circle cx=\"436\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><text x=\"453\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">One</text><path  d=\"M 421 29\nL 451 29\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><circle cx=\"436\" cy=\"29\" r=\"5\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><text x=\"453\" y=\"35\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Two Word</text><path  d=\"M 421 49\nL 451 49\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><circle cx=\"436\" cy=\"49\" r=\"5\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><text x=\"453\" y=\"55\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Three Word Item</text><path  d=\"M 421 69\nL 451 69\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><circle cx=\"436\" cy=\"69\" r=\"5\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><text x=\"453\" y=\"75\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Four Words Is Longer</text></svg>",
+		},
+		{
+			name: "vertical_right_position_custom_font_size",
+			render: func(p *Painter) ([]byte, error) {
+				_, err := NewLegendPainter(p, LegendOption{
+					Data:   []string{"One", "Two Word", "Three Word Item", "Four Words Is Longer"},
+					Orient: OrientVertical,
+					Left:   PositionRight,
+					FontStyle: FontStyle{
+						FontSize: 6.0,
+					},
+				}).Render()
+				if err != nil {
+					return nil, err
+				}
+				return p.Bytes()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 494 9\nL 524 9\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><circle cx=\"509\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><text x=\"526\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:7.7px;font-family:'Roboto Medium',sans-serif\">One</text><path  d=\"M 494 29\nL 524 29\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><circle cx=\"509\" cy=\"29\" r=\"5\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><text x=\"526\" y=\"35\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:7.7px;font-family:'Roboto Medium',sans-serif\">Two Word</text><path  d=\"M 494 49\nL 524 49\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><circle cx=\"509\" cy=\"49\" r=\"5\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><text x=\"526\" y=\"55\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:7.7px;font-family:'Roboto Medium',sans-serif\">Three Word Item</text><path  d=\"M 494 69\nL 524 69\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><circle cx=\"509\" cy=\"69\" r=\"5\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><text x=\"526\" y=\"75\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:7.7px;font-family:'Roboto Medium',sans-serif\">Four Words Is Longer</text></svg>",
+		},
+		{
+			name: "vertical_right_position_with_padding",
+			render: func(p *Painter) ([]byte, error) {
+				_, err := NewLegendPainter(p, LegendOption{
+					Data:    []string{"One", "Two Word", "Three Word Item", "Four Words Is Longer"},
+					Orient:  OrientVertical,
+					Left:    PositionRight,
+					Padding: Box{Top: 120, Left: 120, Right: 120, Bottom: 120},
+				}).Render()
+				if err != nil {
+					return nil, err
+				}
+				return p.Bytes()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 301 124\nL 331 124\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><circle cx=\"316\" cy=\"124\" r=\"5\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><text x=\"333\" y=\"130\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">One</text><path  d=\"M 301 144\nL 331 144\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><circle cx=\"316\" cy=\"144\" r=\"5\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><text x=\"333\" y=\"150\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Two Word</text><path  d=\"M 301 164\nL 331 164\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><circle cx=\"316\" cy=\"164\" r=\"5\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><text x=\"333\" y=\"170\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Three Word Item</text><path  d=\"M 301 184\nL 331 184\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><circle cx=\"316\" cy=\"184\" r=\"5\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><text x=\"333\" y=\"190\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Four Words Is Longer</text></svg>",
+		},
+		{
+			name: "left_position_overflow",
+			render: func(p *Painter) ([]byte, error) {
+				_, err := NewLegendPainter(p, LegendOption{
+					Data: []string{"One", "Two Word", "Three Word Item", "Four Words Is Longer",
+						"Five Words Is Even Longer", "Six Words Is The Longest Tested"},
+					Left: PositionLeft,
+				}).Render()
+				if err != nil {
+					return nil, err
+				}
+				return p.Bytes()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 9\nL 30 9\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><circle cx=\"15\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><text x=\"32\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">One</text><path  d=\"M 80 9\nL 110 9\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><circle cx=\"95\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><text x=\"112\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Two Word</text><path  d=\"M 202 9\nL 232 9\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><circle cx=\"217\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><text x=\"234\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Three Word Item</text><path  d=\"M 369 9\nL 399 9\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><circle cx=\"384\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><text x=\"401\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Four Words Is Longer</text><path  d=\"M 0 24\nL 30 24\" style=\"stroke-width:3;stroke:rgba(115,192,222,1.0);fill:rgba(115,192,222,1.0)\"/><circle cx=\"15\" cy=\"24\" r=\"5\" style=\"stroke-width:3;stroke:rgba(115,192,222,1.0);fill:rgba(115,192,222,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(115,192,222,1.0);fill:rgba(115,192,222,1.0)\"/><text x=\"32\" y=\"30\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Five Words Is Even Longer</text><path  d=\"M 233 24\nL 263 24\" style=\"stroke-width:3;stroke:rgba(59,162,114,1.0);fill:rgba(59,162,114,1.0)\"/><circle cx=\"248\" cy=\"24\" r=\"5\" style=\"stroke-width:3;stroke:rgba(59,162,114,1.0);fill:rgba(59,162,114,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(59,162,114,1.0);fill:rgba(59,162,114,1.0)\"/><text x=\"265\" y=\"30\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Six Words Is The Longest Tested</text></svg>",
+		},
+		{
+			name: "vertical_right_position_overflow",
+			render: func(p *Painter) ([]byte, error) {
+				_, err := NewLegendPainter(p, LegendOption{
+					Data: []string{"One", "Two Word", "Three Word Item", "Four Words Is Longer",
+						"Five Words Is Even Longer", "Six Words Is The Longest Tested"},
+					Orient: OrientVertical,
+					Left:   "440",
+				}).Render()
+				if err != nil {
+					return nil, err
+				}
+				return p.Bytes()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 440 9\nL 470 9\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><circle cx=\"455\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><text x=\"472\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">One</text><path  d=\"M 440 29\nL 470 29\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><circle cx=\"455\" cy=\"29\" r=\"5\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><text x=\"472\" y=\"35\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Two Word</text><path  d=\"M 440 49\nL 470 49\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><circle cx=\"455\" cy=\"49\" r=\"5\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><text x=\"472\" y=\"55\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Three Word Item</text><path  d=\"M 440 69\nL 470 69\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><circle cx=\"455\" cy=\"69\" r=\"5\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><text x=\"472\" y=\"75\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Four Words Is Longer</text><path  d=\"M 440 89\nL 470 89\" style=\"stroke-width:3;stroke:rgba(115,192,222,1.0);fill:rgba(115,192,222,1.0)\"/><circle cx=\"455\" cy=\"89\" r=\"5\" style=\"stroke-width:3;stroke:rgba(115,192,222,1.0);fill:rgba(115,192,222,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(115,192,222,1.0);fill:rgba(115,192,222,1.0)\"/><text x=\"472\" y=\"95\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Five Words Is Even Longer</text><path  d=\"M 440 109\nL 470 109\" style=\"stroke-width:3;stroke:rgba(59,162,114,1.0);fill:rgba(59,162,114,1.0)\"/><circle cx=\"455\" cy=\"109\" r=\"5\" style=\"stroke-width:3;stroke:rgba(59,162,114,1.0);fill:rgba(59,162,114,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(59,162,114,1.0);fill:rgba(59,162,114,1.0)\"/><text x=\"472\" y=\"115\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Six Words Is The Longest Tested</text></svg>",
+		},
+		{
+			name: "right_alignment",
+			render: func(p *Painter) ([]byte, error) {
+				_, err := NewLegendPainter(p, LegendOption{
+					Data:  []string{"One", "Two Word", "Three Word Item", "Four Words Is Longer"},
+					Align: AlignRight,
+				}).Render()
+				if err != nil {
+					return nil, err
+				}
+				return p.Bytes()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><text x=\"27\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">One</text><path  d=\"M 57 9\nL 87 9\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><circle cx=\"72\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><text x=\"107\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Two Word</text><path  d=\"M 179 9\nL 209 9\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><circle cx=\"194\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><text x=\"229\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Three Word Item</text><path  d=\"M 346 9\nL 376 9\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><circle cx=\"361\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><text x=\"396\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Four Words Is Longer</text><path  d=\"M 545 9\nL 575 9\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><circle cx=\"560\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/></svg>",
+		},
+		{
+			name: "vertical_right_alignment",
+			render: func(p *Painter) ([]byte, error) {
+				_, err := NewLegendPainter(p, LegendOption{
+					Data:   []string{"One", "Two Word", "Three Word Item", "Four Words Is Longer"},
+					Orient: OrientVertical,
+					Align:  AlignRight,
+				}).Render()
+				if err != nil {
+					return nil, err
+				}
+				return p.Bytes()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><text x=\"540\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">One</text><path  d=\"M 570 9\nL 600 9\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><circle cx=\"585\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><text x=\"498\" y=\"35\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Two Word</text><path  d=\"M 570 29\nL 600 29\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><circle cx=\"585\" cy=\"29\" r=\"5\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><text x=\"453\" y=\"55\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Three Word Item</text><path  d=\"M 570 49\nL 600 49\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><circle cx=\"585\" cy=\"49\" r=\"5\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><text x=\"421\" y=\"75\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Four Words Is Longer</text><path  d=\"M 570 69\nL 600 69\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><circle cx=\"585\" cy=\"69\" r=\"5\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/></svg>",
+		},
+		{
+			name: "vertical_right_alignment_left_position",
+			render: func(p *Painter) ([]byte, error) {
+				_, err := NewLegendPainter(p, LegendOption{
+					Data:   []string{"One", "Two Word", "Three Word Item", "Four Words Is Longer"},
+					Orient: OrientVertical,
+					Left:   PositionLeft,
+					Align:  AlignRight,
+				}).Render()
+				if err != nil {
+					return nil, err
+				}
+				return p.Bytes()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><text x=\"119\" y=\"15\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">One</text><path  d=\"M 149 9\nL 179 9\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><circle cx=\"164\" cy=\"9\" r=\"5\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(84,112,198,1.0);fill:rgba(84,112,198,1.0)\"/><text x=\"77\" y=\"35\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Two Word</text><path  d=\"M 149 29\nL 179 29\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><circle cx=\"164\" cy=\"29\" r=\"5\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(145,204,117,1.0);fill:rgba(145,204,117,1.0)\"/><text x=\"32\" y=\"55\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Three Word Item</text><path  d=\"M 149 49\nL 179 49\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><circle cx=\"164\" cy=\"49\" r=\"5\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(250,200,88,1.0);fill:rgba(250,200,88,1.0)\"/><text x=\"0\" y=\"75\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Four Words Is Longer</text><path  d=\"M 149 69\nL 179 69\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><circle cx=\"164\" cy=\"69\" r=\"5\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/><path  d=\"\" style=\"stroke-width:3;stroke:rgba(238,102,102,1.0);fill:rgba(238,102,102,1.0)\"/></svg>",
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i)+"-"+tt.name, func(t *testing.T) {

--- a/painter.go
+++ b/painter.go
@@ -156,6 +156,7 @@ func NewPainter(opts PainterOptions, opt ...PainterOption) (*Painter, error) {
 		box: Box{
 			Right:  opts.Width,
 			Bottom: opts.Height,
+			IsSet:  true,
 		},
 		font:         font,
 		outputFormat: opts.OutputFormat,

--- a/table.go
+++ b/table.go
@@ -276,7 +276,8 @@ func (t *tableChart) renderWithInfo(info *renderInfo) (Box, error) {
 	for index, h := range info.rowHeights {
 		color := opt.RowBackgroundColors[index%len(opt.RowBackgroundColors)]
 		child := p.Child(PainterPaddingOption(Box{
-			Top: currentHeight,
+			Top:   currentHeight,
+			IsSet: true,
 		}))
 		child.SetBackground(p.Width(), h, color, true)
 		currentHeight += h
@@ -297,8 +298,9 @@ func (t *tableChart) renderWithInfo(info *renderInfo) (Box, error) {
 				if !tc.FillColor.IsZero() {
 					padding := opt.Padding
 					child := p.Child(PainterPaddingOption(Box{
-						Top:  top + padding.Top,
-						Left: left + padding.Left,
+						Top:   top + padding.Top,
+						Left:  left + padding.Left,
+						IsSet: true,
 					}))
 					w := info.columnWidths[j] - padding.Left - padding.Top
 					h := heights[i] - padding.Top - padding.Bottom
@@ -317,6 +319,7 @@ func (t *tableChart) renderWithInfo(info *renderInfo) (Box, error) {
 	return Box{
 		Right:  info.width,
 		Bottom: info.height,
+		IsSet:  true,
 	}, nil
 }
 

--- a/title.go
+++ b/title.go
@@ -163,5 +163,6 @@ func (t *titlePainter) Render() (Box, error) {
 	return Box{
 		Bottom: titleY,
 		Right:  titleX + width,
+		IsSet:  true,
 	}, nil
 }

--- a/util.go
+++ b/util.go
@@ -153,7 +153,7 @@ func convertPercent(value string) (float64, error) {
 	if !strings.HasSuffix(value, "%") {
 		return -1, fmt.Errorf("not a percent input: %s", value)
 	}
-	v, err := strconv.ParseFloat(strings.ReplaceAll(value, "%", ""), 64)
+	v, err := strconv.ParseFloat(strings.TrimSuffix(value, "%"), 64)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
This commit improves several aspects of legends in the vertical orientation:
1. Previously if the legend has a vertical orientation, and the `Left` value is set with a numeric value, labels which extend past the right boundary would instead be written on the far left side.  Now the numeric value set in `Left` is respected, truncating the label if necessary.
2. Previously setting the legend `Align` to `right` would draw the legend icon on the right side only.  Now this configuration with a vertical orientation will also align the icons and text to the right boundary.  This should better match general expectations with a right alignment.
3. If no `Left` orientation is specified it will choose a `Left` or `Right` orientation (previously `Center`) to better avoid conflicts with the legend.

Example prior to bug `1` being fixed:
![line-chart-orig](https://github.com/user-attachments/assets/06a595cb-9e56-453e-980c-61d07b4ef165)

Example with bug `1` fix:
![line-chart-position_right_fix](https://github.com/user-attachments/assets/70cdf578-e74b-4d55-a6cb-ca26cfba8059)

Example prior to bug `2` being fixed:
![line-chart-orig-align_right](https://github.com/user-attachments/assets/4271c480-503d-4dc6-9a76-c34257866713)

Example with bug `2` fix:
![line-chart-align_right_fix](https://github.com/user-attachments/assets/0ef7de60-d6ad-4ee9-b785-2bc78eff6e46)
