### PR TITLE
Add `SpineLineShow` option for Y-Axis

### DIFF
--- a/line_chart_test.go
+++ b/line_chart_test.go
@@ -377,6 +377,21 @@ func TestLineChart(t *testing.T) {
 			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke-width:0;stroke:none;fill:rgba(255,255,255,1.0)\"/><text x=\"10\" y=\"17\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.5k</text><text x=\"23\" y=\"133\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1k</text><text x=\"13\" y=\"250\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">500</text><text x=\"31\" y=\"367\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">0</text><path  d=\"M 88 332\nL 165 330\nL 242 337\nL 319 329\nL 396 339\nL 473 307\nL 551 311\" style=\"stroke-width:2;stroke:rgba(84,112,198,1.0);fill:none\"/><path  d=\"M 88 169\nL 165 143\nL 242 150\nL 319 143\nL 396 59\nL 473 50\nL 551 52\" style=\"stroke-width:2;stroke:rgba(145,204,117,1.0);fill:none\"/></svg>",
 		},
 		{
+			name:         "yaxis_spine_line_show",
+			defaultTheme: true,
+			makeOptions: func() LineChartOption {
+				opt := makeMinimalLineChartOption()
+				opt.YAxis = []YAxisOption{
+					{
+						LabelCount:    4,
+						SpineLineShow: True(),
+					},
+				}
+				return opt
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke-width:0;stroke:none;fill:rgba(255,255,255,1.0)\"/><path  d=\"M 45 10\nL 50 10\" style=\"stroke-width:1;stroke:rgba(110,112,121,1.0);fill:none\"/><path  d=\"M 45 126\nL 50 126\" style=\"stroke-width:1;stroke:rgba(110,112,121,1.0);fill:none\"/><path  d=\"M 45 243\nL 50 243\" style=\"stroke-width:1;stroke:rgba(110,112,121,1.0);fill:none\"/><path  d=\"M 45 360\nL 50 360\" style=\"stroke-width:1;stroke:rgba(110,112,121,1.0);fill:none\"/><path  d=\"M 50 10\nL 50 360\" style=\"stroke-width:1;stroke:rgba(110,112,121,1.0);fill:none\"/><text x=\"10\" y=\"17\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.5k</text><text x=\"23\" y=\"133\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1k</text><text x=\"13\" y=\"250\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">500</text><text x=\"31\" y=\"367\" style=\"stroke-width:0;stroke:none;fill:rgba(70,70,70,1.0);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">0</text><path  d=\"M 50 10\nL 590 10\" style=\"stroke-width:1;stroke:rgba(224,230,242,1.0);fill:none\"/><path  d=\"M 50 126\nL 590 126\" style=\"stroke-width:1;stroke:rgba(224,230,242,1.0);fill:none\"/><path  d=\"M 50 243\nL 590 243\" style=\"stroke-width:1;stroke:rgba(224,230,242,1.0);fill:none\"/><path  d=\"M 88 332\nL 165 330\nL 242 337\nL 319 329\nL 396 339\nL 473 307\nL 551 311\" style=\"stroke-width:2;stroke:rgba(84,112,198,1.0);fill:none\"/><path  d=\"M 88 169\nL 165 143\nL 242 150\nL 319 143\nL 396 59\nL 473 50\nL 551 52\" style=\"stroke-width:2;stroke:rgba(145,204,117,1.0);fill:none\"/></svg>",
+		},
+		{
 			name:         "zero_data",
 			defaultTheme: true,
 			makeOptions: func() LineChartOption {

--- a/yaxis.go
+++ b/yaxis.go
@@ -31,8 +31,11 @@ type YAxisOption struct {
 	// LabelSkipCount specifies a number of lines between labels where there will be no label and instead just a horizontal line.
 	LabelSkipCount int
 	isCategoryAxis bool
-	// The flag for show axis split line, set this to true will show axis split line
+	// SplitLineShow for showing axis split line, set this to true to show the horizontal axis split lines.
 	SplitLineShow *bool
+	// SpineLineShow can be set to enforce if the vertical spine on the axis should be shown or not.
+	// By default, not shown unless a category axis.
+	SpineLineShow *bool
 }
 
 func (opt *YAxisOption) ToAxisOption(p *Painter) AxisOption {
@@ -72,6 +75,13 @@ func (opt *YAxisOption) ToAxisOption(p *Painter) AxisOption {
 	}
 	if opt.SplitLineShow != nil {
 		axisOpt.SplitLineShow = *opt.SplitLineShow
+	}
+	if opt.SpineLineShow != nil {
+		if *opt.SpineLineShow {
+			axisOpt.StrokeWidth = 1
+		} else {
+			axisOpt.StrokeWidth = -1
+		}
 	}
 	return axisOpt
 }


### PR DESCRIPTION
This option allows the user to force if the y-axis spine should be shown. The prior default behavior is maintained (hidden unless category axis), but this allows the user to control this behavior in case they want the vertical spine.

The y-axis spine was a notable visual difference between `chartdraw` and `charts`.  In addition this was mentioned as a recent configuration gap on the parent project: https://github.com/vicanso/go-charts/issues/94.  For these reasons this seemed like an important styling option to allow.