### PR TITLE
Fix X-Axis label position when rotated

### DIFF
--- a/axis.go
+++ b/axis.go
@@ -133,11 +133,15 @@ func (a *axisPainter) Render() (Box, error) {
 
 	switch opt.Position {
 	case PositionTop:
-		labelPaddingTop = 0
+		if opt.TextRotation != 0 {
+			flatWidth, flatHeight := top.measureTextMaxWidthHeight(opt.Data, 0, fontStyle)
+			labelPaddingTop = flatHeight - textRotationHeightAdjustment(flatWidth, flatHeight, opt.TextRotation)
+		} else {
+			labelPaddingTop = 0
+		}
 		x1 = p.Width()
-		// TODO - should this reference opt.FontStyle or fontStyle with defaults set
-		y0 = labelMargin + int(opt.FontStyle.FontSize)
-		ticksPaddingTop = int(opt.FontStyle.FontSize)
+		y0 = labelMargin + int(fontStyle.FontSize)
+		ticksPaddingTop = int(fontStyle.FontSize)
 		y1 = y0
 	case PositionLeft:
 		x0 = p.Width()
@@ -151,7 +155,12 @@ func (a *axisPainter) Render() (Box, error) {
 		y1 = p.Height()
 		labelPaddingLeft = width - textMaxWidth
 	default:
-		labelPaddingTop = height
+		if opt.TextRotation != 0 {
+			flatWidth, flatHeight := top.measureTextMaxWidthHeight(opt.Data, 0, fontStyle)
+			labelPaddingTop = tickLength<<1 + (textMaxHeight - textRotationHeightAdjustment(flatWidth, flatHeight, opt.TextRotation))
+		} else {
+			labelPaddingTop = height
+		}
 		x1 = p.Width()
 	}
 

--- a/axis_test.go
+++ b/axis_test.go
@@ -40,6 +40,72 @@ func TestAxis(t *testing.T) {
 			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 50 325\nL 50 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 121 325\nL 121 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 192 325\nL 192 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 264 325\nL 264 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 335 325\nL 335 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 407 325\nL 407 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 478 325\nL 478 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 550 325\nL 550 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 50 320\nL 550 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><text x=\"62\" y=\"353\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\">Mon</text><text x=\"136\" y=\"353\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\">Tue</text><text x=\"205\" y=\"353\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\">Wed</text><text x=\"279\" y=\"353\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\">Thu</text><text x=\"358\" y=\"353\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\">Fri</text><text x=\"425\" y=\"353\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\">Sat</text><text x=\"494\" y=\"353\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\">Sun</text></svg>",
 		},
 		{
+			name:       "x-axis_bottom_rotation45",
+			padPainter: true,
+			optionFactory: func() axisOption {
+				opt := XAxisOption{
+					Data:        dayLabels,
+					BoundaryGap: True(),
+					FontStyle: FontStyle{
+						FontSize: 18,
+					},
+					TextRotation: DegreesToRadians(45),
+				}
+				return opt.toAxisOption()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 50 325\nL 50 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 121 325\nL 121 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 192 325\nL 192 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 264 325\nL 264 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 335 325\nL 335 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 407 325\nL 407 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 478 325\nL 478 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 550 325\nL 550 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 50 320\nL 550 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><text x=\"61\" y=\"346\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,61,346)\">Mon</text><text x=\"135\" y=\"346\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,135,346)\">Tue</text><text x=\"204\" y=\"346\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,204,346)\">Wed</text><text x=\"278\" y=\"346\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,278,346)\">Thu</text><text x=\"354\" y=\"346\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,354,346)\">Fri</text><text x=\"423\" y=\"346\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,423,346)\">Sat</text><text x=\"493\" y=\"346\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,493,346)\">Sun</text></svg>",
+		},
+		{
+			name:       "x-axis_bottom_rotation90",
+			padPainter: true,
+			optionFactory: func() axisOption {
+				opt := XAxisOption{
+					Data:        dayLabels,
+					BoundaryGap: True(),
+					FontStyle: FontStyle{
+						FontSize: 18,
+					},
+					TextRotation: DegreesToRadians(90),
+				}
+				return opt.toAxisOption()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 50 325\nL 50 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 121 325\nL 121 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 192 325\nL 192 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 264 325\nL 264 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 335 325\nL 335 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 407 325\nL 407 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 478 325\nL 478 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 550 325\nL 550 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 50 320\nL 550 320\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><text x=\"74\" y=\"330\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,74,330)\">Mon</text><text x=\"145\" y=\"330\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,145,330)\">Tue</text><text x=\"217\" y=\"330\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,217,330)\">Wed</text><text x=\"288\" y=\"330\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,288,330)\">Thu</text><text x=\"360\" y=\"330\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,360,330)\">Fri</text><text x=\"431\" y=\"330\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,431,330)\">Sat</text><text x=\"503\" y=\"330\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,503,330)\">Sun</text></svg>",
+		},
+		{
+			name:       "x-axis_top_rotation45",
+			padPainter: true,
+			optionFactory: func() axisOption {
+				opt := XAxisOption{
+					Data:        dayLabels,
+					BoundaryGap: True(),
+					FontStyle: FontStyle{
+						FontSize: 18,
+					},
+					Position:     PositionTop,
+					TextRotation: DegreesToRadians(45),
+				}
+				return opt.toAxisOption()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 50 314\nL 50 309\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 121 314\nL 121 309\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 192 314\nL 192 309\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 264 314\nL 264 309\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 335 314\nL 335 309\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 407 314\nL 407 309\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 478 314\nL 478 309\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 550 314\nL 550 309\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 50 314\nL 550 314\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><text x=\"61\" y=\"281\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,61,281)\">Mon</text><text x=\"135\" y=\"281\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,135,281)\">Tue</text><text x=\"204\" y=\"281\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,204,281)\">Wed</text><text x=\"278\" y=\"281\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,278,281)\">Thu</text><text x=\"354\" y=\"281\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,354,281)\">Fri</text><text x=\"423\" y=\"281\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,423,281)\">Sat</text><text x=\"493\" y=\"281\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(45.00,493,281)\">Sun</text></svg>",
+		},
+		{
+			name:       "x-axis_top_rotation90",
+			padPainter: true,
+			optionFactory: func() axisOption {
+				opt := XAxisOption{
+					Data:        dayLabels,
+					BoundaryGap: True(),
+					FontStyle: FontStyle{
+						FontSize: 18,
+					},
+					Position:     PositionTop,
+					TextRotation: DegreesToRadians(90),
+				}
+				return opt.toAxisOption()
+			},
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 50 316\nL 50 311\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 121 316\nL 121 311\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 192 316\nL 192 311\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 264 316\nL 264 311\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 335 316\nL 335 311\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 407 316\nL 407 311\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 478 316\nL 478 311\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 550 316\nL 550 311\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 50 316\nL 550 316\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><text x=\"74\" y=\"269\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,74,269)\">Mon</text><text x=\"145\" y=\"269\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,145,269)\">Tue</text><text x=\"217\" y=\"269\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,217,269)\">Wed</text><text x=\"288\" y=\"269\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,288,269)\">Thu</text><text x=\"360\" y=\"269\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,360,269)\">Fri</text><text x=\"431\" y=\"269\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,431,269)\">Sat</text><text x=\"503\" y=\"269\" style=\"stroke:none;fill:rgb(70,70,70);font-size:23px;font-family:'Roboto Medium',sans-serif\" transform=\"rotate(90.00,503,269)\">Sun</text></svg>",
+		},
+		{
 			name: "x-axis_bottom_splitline",
 			optionFactory: func() axisOption {
 				return axisOption{
@@ -104,7 +170,7 @@ func TestAxis(t *testing.T) {
 					Position:  PositionTop,
 				}
 			},
-			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 380\nL 0 375\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 85 380\nL 85 375\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 171 380\nL 171 375\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 257 380\nL 257 375\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 342 380\nL 342 375\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 428 380\nL 428 375\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 514 380\nL 514 375\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 600 380\nL 600 375\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 0 380\nL 600 380\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><text x=\"20\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Mon --</text><text x=\"108\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Tue --</text><text x=\"192\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Wed --</text><text x=\"279\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Thu --</text><text x=\"369\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Fri --</text><text x=\"453\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Sat --</text><text x=\"537\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Sun --</text></svg>",
+			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 392\nL 0 387\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 85 392\nL 85 387\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 171 392\nL 171 387\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 257 392\nL 257 387\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 342 392\nL 342 387\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 428 392\nL 428 387\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 514 392\nL 514 387\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 600 392\nL 600 387\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 0 392\nL 600 392\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><text x=\"20\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Mon --</text><text x=\"108\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Tue --</text><text x=\"192\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Wed --</text><text x=\"279\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Thu --</text><text x=\"369\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Fri --</text><text x=\"453\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Sat --</text><text x=\"537\" y=\"375\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Sun --</text></svg>",
 		},
 		{
 			name: "reduced_label_count",

--- a/chartdraw/donut_chart.go
+++ b/chartdraw/donut_chart.go
@@ -154,7 +154,7 @@ func (pc DonutChart) drawSlices(r Renderer, canvasBox Box, values []Value) {
 	})
 	v.Style.InheritFrom(styletemp).WriteToRenderer(r)
 	r.MoveTo(cx, cy)
-	r.ArcTo(cx, cy, radius/3.5, radius/3.5, DegreesToRadians(0), DegreesToRadians(359))
+	r.ArcTo(cx, cy, radius/3.5, radius/3.5, 0, DegreesToRadians(359))
 	r.LineTo(cx, cy)
 	r.Close()
 	r.FillStroke()

--- a/chartdraw/mathutil.go
+++ b/chartdraw/mathutil.go
@@ -101,7 +101,7 @@ func RadianAdd(base, delta float64) float64 {
 	return math.Mod(math.Mod(value, _2pi)+_2pi, _2pi)
 }
 
-// DegreesAdd adds a delta to a base in radians.
+// DegreesAdd adds a delta to a base in degrees.
 func DegreesAdd(baseDegrees, deltaDegrees float64) float64 {
 	value := baseDegrees + deltaDegrees
 	return math.Mod(math.Mod(value, 360.0)+360.0, 360.0)

--- a/examples/line_chart-3/main.go
+++ b/examples/line_chart-3/main.go
@@ -65,10 +65,11 @@ func main() {
 			LabelSkipCount: 1,
 		}),
 		charts.XAxisOptionFunc(charts.XAxisOption{
-			Data:        xAxisLabels,
-			FontStyle:   axisFont,
-			BoundaryGap: charts.True(),
-			LabelCount:  10,
+			Data:         xAxisLabels,
+			FontStyle:    axisFont,
+			BoundaryGap:  charts.True(),
+			LabelCount:   10,
+			TextRotation: charts.DegreesToRadians(45),
 		}),
 		func(opt *charts.ChartOption) {
 			// disable the symbols and reduce the stroke width to give more fidelity on the line

--- a/examples/line_chart-4/main.go
+++ b/examples/line_chart-4/main.go
@@ -61,6 +61,7 @@ func main() {
 	opt.XAxis.Data = xAxisLabels
 	opt.XAxis.Unit = 40
 	opt.XAxis.LabelCount = 10
+	opt.XAxis.TextRotation = charts.DegreesToRadians(45)
 	opt.XAxis.BoundaryGap = charts.True()
 	opt.XAxis.FontStyle = charts.FontStyle{
 		FontSize: 6.0,

--- a/util.go
+++ b/util.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+
+	"github.com/go-analyze/charts/chartdraw"
 )
 
 // True returns a pointer to a true bool, useful for configuration.
@@ -153,6 +155,16 @@ const kValue = float64(1000)
 const mValue = kValue * kValue
 const gValue = mValue * kValue
 const tValue = gValue * kValue
+
+// DegreesToRadians returns degrees as radians.
+func DegreesToRadians(degrees float64) float64 {
+	return chartdraw.DegreesToRadians(degrees)
+}
+
+// RadiansToDegrees translates a radian value to a degree value.
+func RadiansToDegrees(value float64) float64 {
+	return chartdraw.RadiansToDegrees(value)
+}
 
 // FormatValueHumanizeShort takes in a value and a specified precision, rounding to the specified precision and
 // returning a human friendly number string including commas. If the value is over 1,000 it will be reduced to a


### PR DESCRIPTION
This PR fixes issue #32. Prior logic would place labels off when rotation was specified, resulting in users needing to make manual padding adjustments to get labels positioned correctly.

This fixes the issue by creating a function which provides a calculation so that rotation results in text always positioning upwards (similar to how it's written without rotation). This makes logic easier to implement, and also fixes the discovered issue.

Additionally `DegreesToRadians` is now available in the charts package since all our configuration accepts radians.