### PR TITLE
[v0.5] Horizontal Bar Chart: only accept a single Y Axis

### DIFF
--- a/charts.go
+++ b/charts.go
@@ -434,13 +434,21 @@ func Render(opt ChartOption, opts ...OptionFunc) (*Painter, error) {
 
 	// horizontal bar chart
 	if len(horizontalBarSeriesList) != 0 {
+		var yAxis YAxisOption
+		if len(opt.YAxis) > 0 {
+			if len(opt.YAxis) > 1 {
+				return nil, errors.New("horizontal bar chart only accepts a single Y-Axis")
+			}
+			yAxis = opt.YAxis[0]
+		}
+
 		handler.Add(func() error {
 			_, err := newHorizontalBarChart(p, HorizontalBarChartOption{
 				Theme:       opt.Theme,
 				Font:        opt.Font,
 				BarHeight:   opt.BarHeight,
 				BarMargin:   opt.BarMargin,
-				YAxis:       opt.YAxis,
+				YAxis:       yAxis,
 				StackSeries: opt.StackSeries,
 			}).render(renderResult, horizontalBarSeriesList)
 			return err

--- a/examples/horizontal_bar_chart-2/main.go
+++ b/examples/horizontal_bar_chart-2/main.go
@@ -38,11 +38,9 @@ func main() {
 	opt.Legend.Data = []string{
 		"2011", "2012",
 	}
-	opt.YAxis = []charts.YAxisOption{
-		{
-			Data: []string{
-				"UN", "Brazil", "Indonesia", "USA", "India", "China", "World",
-			},
+	opt.YAxis = charts.YAxisOption{
+		Data: []string{
+			"UN", "Brazil", "Indonesia", "USA", "India", "China", "World",
 		},
 	}
 

--- a/examples/horizontal_bar_chart-3/main.go
+++ b/examples/horizontal_bar_chart-3/main.go
@@ -44,11 +44,9 @@ func main() {
 		"2011", "2012",
 	}
 	opt.XAxis.Show = charts.False()
-	opt.YAxis = []charts.YAxisOption{
-		{
-			Data: []string{
-				"UN", "Brazil", "Indonesia", "USA", "India", "China", "World",
-			},
+	opt.YAxis = charts.YAxisOption{
+		Data: []string{
+			"UN", "Brazil", "Indonesia", "USA", "India", "China", "World",
 		},
 	}
 

--- a/examples/multiple_charts-2/main.go
+++ b/examples/multiple_charts-2/main.go
@@ -70,11 +70,9 @@ func main() {
 				"2011", "2012",
 			},
 		},
-		YAxis: []charts.YAxisOption{
-			{
-				Data: []string{
-					"USA", "India", "China", "World",
-				},
+		YAxis: charts.YAxisOption{
+			Data: []string{
+				"USA", "India", "China", "World",
 			},
 		},
 		SeriesList: charts.NewSeriesListHorizontalBar([][]float64{

--- a/horizontal_bar_chart.go
+++ b/horizontal_bar_chart.go
@@ -19,7 +19,6 @@ func NewHorizontalBarChartOptionWithData(data [][]float64) HorizontalBarChartOpt
 		Padding:        defaultPadding,
 		Theme:          GetDefaultTheme(),
 		Font:           GetDefaultFont(),
-		YAxis:          make([]YAxisOption, sl.getYAxisCount()),
 		ValueFormatter: defaultValueFormatter,
 	}
 }
@@ -43,8 +42,8 @@ type HorizontalBarChartOption struct {
 	SeriesLabelPosition string
 	// XAxis are options for the x-axis.
 	XAxis XAxisOption
-	// YAxis are options for the y-axis (at most two).
-	YAxis []YAxisOption
+	// YAxis are options for the y-axis.
+	YAxis YAxisOption
 	// Title are options for rendering the title.
 	Title TitleOption
 	// Legend are options for the data legend.
@@ -193,7 +192,7 @@ func (h *horizontalBarChart) Render() (Box, error) {
 		seriesList:     opt.SeriesList,
 		stackSeries:    flagIs(true, opt.StackSeries),
 		xAxis:          &h.opt.XAxis,
-		yAxis:          opt.YAxis,
+		yAxis:          []YAxisOption{opt.YAxis},
 		title:          opt.Title,
 		legend:         &h.opt.Legend,
 		valueFormatter: opt.ValueFormatter,

--- a/horizontal_bar_chart_test.go
+++ b/horizontal_bar_chart_test.go
@@ -28,11 +28,9 @@ func makeBasicHorizontalBarChartOption() HorizontalBarChartOption {
 				"2011", "2012",
 			},
 		},
-		YAxis: []YAxisOption{
-			{
-				Data: []string{
-					"Brazil", "Indonesia", "USA", "India", "China", "World",
-				},
+		YAxis: YAxisOption{
+			Data: []string{
+				"Brazil", "Indonesia", "USA", "India", "China", "World",
 			},
 		},
 	}
@@ -43,12 +41,10 @@ func makeMinimalHorizontalBarChartOption() HorizontalBarChartOption {
 		{12, 24},
 		{24, 48},
 	})
-	opt.YAxis = []YAxisOption{
-		{
-			Show: False(),
-			Data: []string{
-				"A", "B",
-			},
+	opt.YAxis = YAxisOption{
+		Show: False(),
+		Data: []string{
+			"A", "B",
 		},
 	}
 	opt.XAxis.Show = False()
@@ -81,11 +77,9 @@ func makeFullHorizontalBarChartStackedOption() HorizontalBarChartOption {
 		Legend: LegendOption{
 			Data: dataLabels,
 		},
-		YAxis: []YAxisOption{
-			{
-				Data: []string{
-					"1", "2", "3", "4", "5", "6", "7", "8",
-				},
+		YAxis: YAxisOption{
+			Data: []string{
+				"1", "2", "3", "4", "5", "6", "7", "8",
 			},
 		},
 	}
@@ -101,7 +95,6 @@ func TestNewHorizontalBarChartOptionWithData(t *testing.T) {
 
 	assert.Len(t, opt.SeriesList, 2)
 	assert.Equal(t, ChartTypeHorizontalBar, opt.SeriesList[0].Type)
-	assert.Len(t, opt.YAxis, 1)
 	assert.Equal(t, defaultPadding, opt.Padding)
 
 	p := NewPainter(PainterOptions{})
@@ -181,7 +174,7 @@ func TestHorizontalBarChart(t *testing.T) {
 				opt := makeBasicHorizontalBarChartOption()
 				opt.Title.Show = False()
 				opt.XAxis.Show = False()
-				opt.YAxis[0].Show = False()
+				opt.YAxis.Show = False()
 				opt.Legend.Show = False()
 				opt.BarHeight = 1000
 				return opt


### PR DESCRIPTION
Because of the horizontal layout two Y axis's do not make sense for this chart.  Prior to this API change it would result in a confusing / bugged chart if a second Y-Axis is specified.

Because this is API breaking this wont be merged until we are ready to consider the `v0.5.0` release.