### PR TITLE
[v0.5] Remove Deprecated and Replaced API

### DIFF
--- a/bar_chart.go
+++ b/bar_chart.go
@@ -184,7 +184,7 @@ func (b *barChart) render(result *defaultRenderResult, seriesList SeriesList) (B
 				labelY := top
 				radians := float64(0)
 				fontStyle := series.Label.FontStyle
-				labelBottom := (opt.SeriesLabelPosition == PositionBottom || series.Label.Position == PositionBottom) && !stackedSeries
+				labelBottom := opt.SeriesLabelPosition == PositionBottom && !stackedSeries
 				if labelBottom {
 					labelY = barMaxHeight
 					radians = -math.Pi / 2 // Rotated label at the bottom

--- a/chart_option.go
+++ b/chart_option.go
@@ -41,8 +41,8 @@ type ChartOption struct {
 	SymbolShow *bool
 	// LineStrokeWidth is the stroke width for line charts.
 	LineStrokeWidth float64
-	// FillArea set to true to fill the area under the line in line charts
-	FillArea bool
+	// FillArea set to *true to fill the area under the line in line charts
+	FillArea *bool
 	// FillOpacity is the opacity (alpha) of the area fill in line charts.
 	FillOpacity uint8
 	// BarWidth is the width of the bars for bar charts.

--- a/chartdraw/drawing/color.go
+++ b/chartdraw/drawing/color.go
@@ -135,11 +135,6 @@ func ColorFromRGBA(color string) Color {
 	return c
 }
 
-// Deprecated: ColorFromRGB is deprecated, use ColorFromRGBA to get colors from RGB or RGBA format strings.
-func ColorFromRGB(rgb string) (output Color) {
-	return ColorFromRGBA(rgb)
-}
-
 func parseHex(hex string) uint8 {
 	v, _ := strconv.ParseInt(hex, 16, 16)
 	return uint8(v)

--- a/chartdraw/drawing/raster_graphic_context.go
+++ b/chartdraw/drawing/raster_graphic_context.go
@@ -76,22 +76,10 @@ func (rgc *RasterGraphicContext) DrawImage(img image.Image) {
 	DrawImage(img, rgc.img, rgc.current.Tr, draw.Over, BilinearFilter)
 }
 
-// Deprecated: FillString is deprecated, use FillStringAt with (0, 0) for the position.
-func (rgc *RasterGraphicContext) FillString(text string) (cursor float64, err error) {
-	cursor, err = rgc.FillStringAt(text, 0, 0)
-	return
-}
-
 // FillStringAt draws the text at the specified point (x, y).
 func (rgc *RasterGraphicContext) FillStringAt(text string, x, y float64) (cursor float64, err error) {
 	cursor, err = rgc.CreateStringPath(text, x, y)
 	rgc.Fill()
-	return
-}
-
-// Deprecated: StrokeString is deprecated, use StrokeStringAt with (0, 0) for the position.
-func (rgc *RasterGraphicContext) StrokeString(text string) (cursor float64, err error) {
-	cursor, err = rgc.StrokeStringAt(text, 0, 0)
 	return
 }
 

--- a/examples/line_chart-area/main.go
+++ b/examples/line_chart-area/main.go
@@ -57,7 +57,7 @@ func main() {
 		}),
 		// setup fill styling below
 		func(opt *charts.ChartOption) {
-			opt.FillArea = true                    // shade the area under the line
+			opt.FillArea = charts.True()           // shade the area under the line
 			opt.FillOpacity = 150                  // set the fill opacity a little lighter than default
 			opt.XAxis.BoundaryGap = charts.False() // BoundaryGap is less appealing when enabling FillArea
 		},

--- a/examples/web-1/main.go
+++ b/examples/web-1/main.go
@@ -262,8 +262,7 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 					},
 					Type: charts.ChartTypeBar,
 					Label: charts.SeriesLabel{
-						Show:     charts.True(),
-						Position: charts.PositionBottom,
+						Show: charts.True(),
 					},
 				},
 			},

--- a/examples/web-1/main.go
+++ b/examples/web-1/main.go
@@ -228,7 +228,7 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 			SeriesList: charts.NewSeriesListLine([][]float64{
 				{120, 132, 101, 134, 90, 230, 210},
 			}),
-			FillArea: true,
+			FillArea: charts.True(),
 		},
 		// histogram
 		{

--- a/funnel_chart.go
+++ b/funnel_chart.go
@@ -83,9 +83,6 @@ func (f *funnelChart) render(result *defaultRenderResult, seriesList SeriesList)
 			if item.Label.ValueFormatter != nil {
 				textList[index] = item.Label.ValueFormatter(value)
 			} else {
-				if item.Label.FormatTemplate == "" {
-					item.Label.FormatTemplate = item.Label.Formatter
-				}
 				textList[index] = labelFormatFunnel(seriesNames, item.Label.FormatTemplate, index, value, percent)
 			}
 		}

--- a/horizontal_bar_chart.go
+++ b/horizontal_bar_chart.go
@@ -141,7 +141,7 @@ func (h *horizontalBarChart) render(result *defaultRenderResult, seriesList Seri
 				fontStyle := series.Label.FontStyle
 				labelX := right
 				labelY := y + (barHeight >> 1)
-				labelLeft := (opt.SeriesLabelPosition == PositionLeft || series.Label.Position == PositionLeft) && !stackedSeries
+				labelLeft := opt.SeriesLabelPosition == PositionLeft && !stackedSeries
 				if labelLeft {
 					labelX = 0
 				}

--- a/line_chart.go
+++ b/line_chart.go
@@ -66,9 +66,8 @@ type LineChartOption struct {
 	// smoother lines. Because the tension smooths out the line, the line will no longer hit the data points exactly.
 	// The more variable the points, and the higher the tension, the more the line will be moved from the points.
 	StrokeSmoothingTension float64
-	// TODO - make FillArea a pointer so that it can be disabled for stacking, update StackSeries docs when done
 	// FillArea set this to true to fill the area below the line.
-	FillArea bool
+	FillArea *bool
 	// FillOpacity is the opacity (alpha) of the area fill.
 	FillOpacity uint8
 	// ValueFormatter defines how float values should be rendered to strings, notably for numeric axis labels.
@@ -85,9 +84,12 @@ func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (
 	seriesPainter := result.seriesPainter
 
 	stackedSeries := flagIs(true, opt.StackSeries)
-	fillArea := stackedSeries || opt.FillArea // fill area defaults to on if the series is stacked
-	boundaryGap := !fillArea                  // boundary gap default enabled unless fill area is set
-	if opt.XAxis.BoundaryGap != nil {
+	fillArea := stackedSeries // fill area defaults to on if the series is stacked
+	if opt.FillArea != nil {  // default override
+		fillArea = *opt.FillArea
+	}
+	boundaryGap := !fillArea          // boundary gap default enabled unless fill area is set
+	if opt.XAxis.BoundaryGap != nil { // default override
 		boundaryGap = *opt.XAxis.BoundaryGap
 	}
 	xDivideCount := len(opt.XAxis.Data)
@@ -287,7 +289,10 @@ func (l *lineChart) Render() (Box, error) {
 	}
 	// boundary gap default must be set here as it's used by the x-axis as well
 	if opt.XAxis.BoundaryGap == nil {
-		fillArea := flagIs(true, opt.StackSeries) || opt.FillArea
+		fillArea := flagIs(true, opt.StackSeries) // fill area default based on StackedSeries state
+		if opt.FillArea != nil {                  // default override
+			fillArea = *opt.FillArea
+		}
 		boundaryGap := !fillArea // boundary gap default enabled unless fill area is set
 		l.opt.XAxis.BoundaryGap = &boundaryGap
 	}

--- a/line_chart_test.go
+++ b/line_chart_test.go
@@ -595,7 +595,7 @@ func TestLineChart(t *testing.T) {
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
 				opt.SeriesList[0].Data[3] = GetNullValue()
-				opt.FillArea = true
+				opt.FillArea = True()
 				return opt
 			},
 			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><text x=\"10\" y=\"17\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.44k</text><text x=\"10\" y=\"55\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.28k</text><text x=\"10\" y=\"94\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.12k</text><text x=\"22\" y=\"133\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">960</text><text x=\"22\" y=\"172\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">800</text><text x=\"22\" y=\"211\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">640</text><text x=\"22\" y=\"250\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">480</text><text x=\"22\" y=\"289\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">320</text><text x=\"22\" y=\"328\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">160</text><text x=\"40\" y=\"367\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">0</text><path  d=\"M 59 10\nL 590 10\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 48\nL 590 48\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 87\nL 590 87\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 126\nL 590 126\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 165\nL 590 165\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 204\nL 590 204\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 243\nL 590 243\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 282\nL 590 282\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 321\nL 590 321\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 331\nL 147 328\nL 236 336\" style=\"stroke:none;fill:rgba(84,112,198,0.8)\"/><path  d=\"M 413 339\nL 501 305\nL 590 309\nL 590 360\nL 59 360\nL 59 331\" style=\"stroke:none;fill:rgba(84,112,198,0.8)\"/><path  d=\"M 59 331\nL 147 328\nL 236 336\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 413 339\nL 501 305\nL 590 309\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 59 161\nL 147 134\nL 236 142\nL 324 133\nL 413 47\nL 501 37\nL 590 40\nL 590 360\nL 59 360\nL 59 161\" style=\"stroke:none;fill:rgba(145,204,117,0.8)\"/><path  d=\"M 59 161\nL 147 134\nL 236 142\nL 324 133\nL 413 47\nL 501 37\nL 590 40\" style=\"stroke-width:2;stroke:rgb(145,204,117);fill:none\"/></svg>",
@@ -618,7 +618,7 @@ func TestLineChart(t *testing.T) {
 				opt := makeMinimalLineChartOption()
 				opt.StrokeSmoothingTension = 0.8
 				opt.SeriesList[0].Data[3] = GetNullValue()
-				opt.FillArea = true
+				opt.FillArea = True()
 				return opt
 			},
 			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><text x=\"10\" y=\"17\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.44k</text><text x=\"10\" y=\"55\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.28k</text><text x=\"10\" y=\"94\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.12k</text><text x=\"22\" y=\"133\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">960</text><text x=\"22\" y=\"172\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">800</text><text x=\"22\" y=\"211\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">640</text><text x=\"22\" y=\"250\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">480</text><text x=\"22\" y=\"289\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">320</text><text x=\"22\" y=\"328\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">160</text><text x=\"40\" y=\"367\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">0</text><path  d=\"M 59 10\nL 590 10\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 48\nL 590 48\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 87\nL 590 87\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 126\nL 590 126\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 165\nL 590 165\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 204\nL 590 204\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 243\nL 590 243\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 282\nL 590 282\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 321\nL 590 321\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 331\nQ147,328 182,331\nQ147,328 236,336\nM 413 339\nQ501,305 536,306\nQ501,305 590,309\nL 590 360\nL 59 360\nL 59 331\" style=\"stroke:none;fill:rgba(84,112,198,0.8)\"/><path  d=\"M 59 331\nQ147,328 182,331\nQ147,328 236,336\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 413 339\nQ501,305 536,306\nQ501,305 590,309\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 59 161\nQ147,134 182,137\nQ236,142 271,138\nQ324,133 359,98\nQ413,47 448,43\nQ501,37 536,38\nQ501,37 590,40\nL 590 360\nL 59 360\nL 59 161\" style=\"stroke:none;fill:rgba(145,204,117,0.8)\"/><path  d=\"M 59 161\nQ147,134 182,137\nQ236,142 271,138\nQ324,133 359,98\nQ413,47 448,43\nQ501,37 536,38\nQ501,37 590,40\" style=\"stroke-width:2;stroke:rgb(145,204,117);fill:none\"/></svg>",
@@ -628,7 +628,7 @@ func TestLineChart(t *testing.T) {
 			defaultTheme: true,
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
-				opt.FillArea = true
+				opt.FillArea = True()
 				opt.FillOpacity = 100
 				return opt
 			},
@@ -639,7 +639,7 @@ func TestLineChart(t *testing.T) {
 			defaultTheme: true,
 			makeOptions: func() LineChartOption {
 				opt := makeFullLineChartOption()
-				opt.FillArea = true
+				opt.FillArea = True()
 				opt.FillOpacity = 100
 				opt.XAxis.BoundaryGap = True()
 				return opt
@@ -651,7 +651,7 @@ func TestLineChart(t *testing.T) {
 			defaultTheme: true,
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
-				opt.FillArea = true
+				opt.FillArea = True()
 				opt.StrokeSmoothingTension = 0.8
 				opt.XAxis.BoundaryGap = True()
 				return opt
@@ -663,7 +663,7 @@ func TestLineChart(t *testing.T) {
 			defaultTheme: true,
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
-				opt.FillArea = true
+				opt.FillArea = True()
 				opt.StrokeSmoothingTension = 0.8
 				opt.XAxis.BoundaryGap = False()
 				return opt

--- a/painter.go
+++ b/painter.go
@@ -379,11 +379,6 @@ func (p *Painter) drawSmoothCurve(points []Point, tension float64, dotForSingleP
 	p.quadCurveTo(points[n-2].X, points[n-2].Y, points[n-1].X, points[n-1].Y)
 }
 
-// Deprecated: SetBackground is Deprecated, use FilledRect with zero for the stroke width.
-func (p *Painter) SetBackground(width, height int, color Color) {
-	p.FilledRect(0, 0, width, height, color, color, 0.0)
-}
-
 // drawBackground fills the entire painter area with the given color.
 func (p *Painter) drawBackground(color Color) {
 	p.FilledRect(0, 0, p.Width(), p.Height(), color, color, 0.0)

--- a/painter_test.go
+++ b/painter_test.go
@@ -162,13 +162,6 @@ func TestPainterExternal(t *testing.T) {
 			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 300\"><path  d=\"M 15 30\nQ25,50 27,55\nQ35,70 37,67\nQ45,60 47,57\nQ55,50 57,60\nQ55,50 65,90\" style=\"stroke-width:1;stroke:black;fill:none\"/></svg>",
 		},
 		{
-			name: "background",
-			fn: func(p *Painter) {
-				p.SetBackground(400, 300, ColorWhite)
-			},
-			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 300\"><path  d=\"M 5 10\nL 405 10\nL 405 310\nL 5 310\nL 5 10\" style=\"stroke:none;fill:white\"/></svg>",
-		},
-		{
 			name: "filled_rect",
 			fn: func(p *Painter) {
 				p.FilledRect(0, 0, 400, 300, ColorWhite, ColorWhite, 0.0)

--- a/pie_chart.go
+++ b/pie_chart.go
@@ -108,9 +108,6 @@ func newSector(cx int, cy int, radius float64, labelRadius float64, value float6
 		if series.Label.ValueFormatter != nil {
 			s.label = series.Label.ValueFormatter(s.value)
 		} else {
-			if series.Label.FormatTemplate == "" {
-				series.Label.FormatTemplate = series.Label.Formatter
-			}
 			s.label = labelFormatPie([]string{label}, series.Label.FormatTemplate, 0, s.value, s.percent)
 		}
 	}

--- a/pie_chart_test.go
+++ b/pie_chart_test.go
@@ -87,8 +87,8 @@ func TestPieChart(t *testing.T) {
 				return PieChartOption{
 					SeriesList: NewSeriesListPie(values, PieSeriesOption{
 						Label: SeriesLabel{
-							Show:      True(),
-							Formatter: "{b} ({c} ≅ {d})",
+							Show:           True(),
+							FormatTemplate: "{b} ({c} ≅ {d})",
 						},
 						Radius: "200",
 					}),
@@ -150,8 +150,8 @@ func TestPieChart(t *testing.T) {
 				return PieChartOption{
 					SeriesList: NewSeriesListPie(values, PieSeriesOption{
 						Label: SeriesLabel{
-							Show:      True(),
-							Formatter: "{b} ({c} ≅ {d})",
+							Show:           True(),
+							FormatTemplate: "{b} ({c} ≅ {d})",
 						},
 						Radius: "200",
 					}),
@@ -244,8 +244,8 @@ func TestPieChart(t *testing.T) {
 				return PieChartOption{
 					SeriesList: NewSeriesListPie(values, PieSeriesOption{
 						Label: SeriesLabel{
-							Show:      True(),
-							Formatter: "{b} ({c} ≅ {d})",
+							Show:           True(),
+							FormatTemplate: "{b} ({c} ≅ {d})",
 						},
 						Radius: "150",
 					}),

--- a/series.go
+++ b/series.go
@@ -31,8 +31,6 @@ func newSeriesListFromValues(values [][]float64, chartType string, label SeriesL
 }
 
 type SeriesLabel struct {
-	// Deprecated: Formatter is deprecated, use FormatTemplate as a direct replacement.
-	Formatter string
 	// FormatTemplate is a string template for formatting the data label.
 	// {b}: the name of a data item.
 	// {c}: the value of a data item.
@@ -46,9 +44,6 @@ type SeriesLabel struct {
 	Show *bool
 	// Distance to the host graphic element.
 	Distance int // TODO - do we want to replace with just Offset?
-	// Deprecated: Position is deprecated, this value was only used on bar and horizontal bar charts. Instead use
-	// SeriesLabelPosition on those chart options directly.
-	Position string
 	// Offset specifies an offset from the position.
 	Offset OffsetInt
 }
@@ -142,12 +137,6 @@ func (sl SeriesList) getYAxisCount() int {
 		}
 	}
 	return 1
-}
-
-// Deprecated: GetMinMax is deprecated, instead use Series.Summary().  For example seriesList[0].Summary().
-func (sl SeriesList) GetMinMax(yaxisIndex int) (float64, float64) {
-	min, max, _ := sl.getMinMaxSumMax(yaxisIndex, false)
-	return min, max
 }
 
 // getMinMaxSumMax returns the min, max, and maximum sum of the series for a given y-axis index (either 0 or 1).

--- a/series_label.go
+++ b/series_label.go
@@ -57,9 +57,6 @@ func (o *seriesLabelPainter) Add(value labelValue) {
 	if label.ValueFormatter != nil {
 		text = label.ValueFormatter(value.value)
 	} else {
-		if label.FormatTemplate == "" {
-			label.FormatTemplate = label.Formatter
-		}
 		text = labelFormatValue(o.seriesNames, label.FormatTemplate, value.index, value.value, -1)
 	}
 	labelStyle := FontStyle{


### PR DESCRIPTION
This PR contains the API replaced and removed for the v0.5 release.  Additional v0.5 PR's:
* #40 - Horizontal Bar Chart only accept a single Y Axis Option Struct

Before merging we will describe all API changes on our version migration guide here: https://github.com/go-analyze/charts/wiki/Version-Migration-Guide