### PR TITLE
[v0.5] - `Series` API change

### DIFF
--- a/bar_chart_test.go
+++ b/bar_chart_test.go
@@ -84,7 +84,7 @@ func TestNewBarChartOptionWithData(t *testing.T) {
 	})
 
 	assert.Len(t, opt.SeriesList, 2)
-	assert.Equal(t, ChartTypeBar, opt.SeriesList[0].Type)
+	assert.Equal(t, ChartTypeBar, opt.SeriesList[0].getType())
 	assert.Len(t, opt.YAxis, 1)
 	assert.Equal(t, defaultPadding, opt.Padding)
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -20,7 +20,6 @@ func makeDefaultMultiChartOptions() ChartOption {
 		},
 		YAxis: []YAxisOption{
 			{
-
 				Min: Ptr(0.0),
 				Max: Ptr(90.0),
 			},
@@ -29,11 +28,11 @@ func makeDefaultMultiChartOptions() ChartOption {
 			NewSeriesListLine([][]float64{
 				{56.5, 82.1, 88.7, 70.1, 53.4, 85.1},
 				{51.1, 51.4, 55.1, 53.3, 73.8, 68.7},
-			}),
+			}).ToGenericSeriesList(),
 			NewSeriesListBar([][]float64{
 				{40.1, 62.2, 69.5, 36.4, 45.2, 32.5},
 				{25.2, 37.1, 41.2, 18, 33.9, 49.1},
-			})...),
+			}).ToGenericSeriesList()...),
 		Children: []ChartOption{
 			{
 				Legend: LegendOption{
@@ -50,7 +49,7 @@ func makeDefaultMultiChartOptions() ChartOption {
 					435.9, 354.3, 285.9, 204.5,
 				}, PieSeriesOption{
 					Radius: "35%",
-				}),
+				}).ToGenericSeriesList(),
 			},
 		},
 	}

--- a/chart_option.go
+++ b/chart_option.go
@@ -30,8 +30,8 @@ type ChartOption struct {
 	Font *truetype.Font
 	// Box specifies the canvas box for the chart.
 	Box Box
-	// SeriesList provides the data series.
-	SeriesList SeriesList
+	// SeriesList provides the population data for the charts, constructed through NewSeriesListGeneric.
+	SeriesList GenericSeriesList
 	// StackSeries if set to *true the lines will be layered or stacked. This option significantly changes the chart
 	// visualization, please see the specific chart docs for full details.
 	StackSeries *bool
@@ -228,7 +228,7 @@ func (o *ChartOption) fillDefault() error {
 	o.Width = getDefaultInt(o.Width, defaultChartWidth)
 	o.Height = getDefaultInt(o.Height, defaultChartHeight)
 
-	yaxisCount := o.SeriesList.getYAxisCount()
+	yaxisCount := getSeriesYAxisCount(o.SeriesList)
 	if yaxisCount < 0 {
 		return errors.New("series specified invalid y-axis index")
 	}
@@ -267,41 +267,41 @@ func fillThemeDefaults(defaultTheme ColorPalette, title *TitleOption, legend *Le
 // LineRender line chart render.
 func LineRender(values [][]float64, opts ...OptionFunc) (*Painter, error) {
 	return Render(ChartOption{
-		SeriesList: NewSeriesListLine(values),
+		SeriesList: NewSeriesListGeneric(values, ChartTypeLine),
 	}, opts...)
 }
 
 // BarRender bar chart render.
 func BarRender(values [][]float64, opts ...OptionFunc) (*Painter, error) {
 	return Render(ChartOption{
-		SeriesList: NewSeriesListBar(values),
+		SeriesList: NewSeriesListGeneric(values, ChartTypeBar),
 	}, opts...)
 }
 
 // HorizontalBarRender horizontal bar chart render.
 func HorizontalBarRender(values [][]float64, opts ...OptionFunc) (*Painter, error) {
 	return Render(ChartOption{
-		SeriesList: NewSeriesListHorizontalBar(values),
+		SeriesList: NewSeriesListGeneric(values, ChartTypeHorizontalBar),
 	}, opts...)
 }
 
 // PieRender pie chart render.
 func PieRender(values []float64, opts ...OptionFunc) (*Painter, error) {
 	return Render(ChartOption{
-		SeriesList: NewSeriesListPie(values),
+		SeriesList: NewSeriesListPie(values).ToGenericSeriesList(),
 	}, opts...)
 }
 
 // RadarRender radar chart render.
 func RadarRender(values [][]float64, opts ...OptionFunc) (*Painter, error) {
 	return Render(ChartOption{
-		SeriesList: NewSeriesListRadar(values),
+		SeriesList: NewSeriesListGeneric(values, ChartTypeRadar),
 	}, opts...)
 }
 
 // FunnelRender funnel chart render.
 func FunnelRender(values []float64, opts ...OptionFunc) (*Painter, error) {
 	return Render(ChartOption{
-		SeriesList: NewSeriesListFunnel(values),
+		SeriesList: NewSeriesListFunnel(values).ToGenericSeriesList(),
 	}, opts...)
 }

--- a/chart_option_test.go
+++ b/chart_option_test.go
@@ -54,7 +54,7 @@ func TestChartOptionSeriesShowLabel(t *testing.T) {
 	t.Parallel()
 
 	opt := ChartOption{
-		SeriesList: NewSeriesListPie([]float64{1, 2}),
+		SeriesList: NewSeriesListPie([]float64{1, 2}).ToGenericSeriesList(),
 	}
 	SeriesShowLabel(true)(&opt)
 	assert.True(t, flagIs(true, opt.SeriesList[0].Label.Show))
@@ -63,9 +63,8 @@ func TestChartOptionSeriesShowLabel(t *testing.T) {
 	assert.True(t, flagIs(false, opt.SeriesList[0].Label.Show))
 }
 
-func newNoTypeSeriesListFromValues(values [][]float64) SeriesList {
-	return newSeriesListFromValues(values, "",
-		SeriesLabel{}, nil, "", SeriesMarkPoint{}, SeriesMarkLine{})
+func newNoTypeSeriesListFromValues(values [][]float64) GenericSeriesList {
+	return NewSeriesListGeneric(values, "")
 }
 
 func TestChartOptionMarkLine(t *testing.T) {
@@ -273,7 +272,7 @@ func TestChildRender(t *testing.T) {
 			SeriesList: NewSeriesListHorizontalBar([][]float64{
 				{70, 90, 110, 130},
 				{80, 100, 120, 140},
-			}),
+			}).ToGenericSeriesList(),
 			Legend: LegendOption{
 				SeriesNames: []string{"2011", "2012"},
 			},

--- a/echarts.go
+++ b/echarts.go
@@ -253,20 +253,20 @@ type EChartsSeries struct {
 }
 type EChartsSeriesList []EChartsSeries
 
-func (esList EChartsSeriesList) ToSeriesList() SeriesList {
-	seriesList := make(SeriesList, 0, len(esList))
+func (esList EChartsSeriesList) ToSeriesList() GenericSeriesList {
+	seriesList := make([]GenericSeries, 0, len(esList))
 	for _, item := range esList {
 		// if pie, each sub-recommendation generates a series
 		if item.Type == ChartTypePie {
 			for _, dataItem := range item.Data {
-				seriesList = append(seriesList, Series{
+				seriesList = append(seriesList, GenericSeries{
 					Type: item.Type,
 					Name: dataItem.Name,
 					Label: SeriesLabel{
 						Show: Ptr(true),
 					},
 					Radius: item.Radius,
-					Data:   []float64{dataItem.Value.First()},
+					Values: []float64{dataItem.Value.First()},
 				})
 			}
 			continue
@@ -274,10 +274,10 @@ func (esList EChartsSeriesList) ToSeriesList() SeriesList {
 		if item.Type == ChartTypeRadar ||
 			item.Type == ChartTypeFunnel {
 			for _, dataItem := range item.Data {
-				seriesList = append(seriesList, Series{
-					Name: dataItem.Name,
-					Type: item.Type,
-					Data: dataItem.Value.values,
+				seriesList = append(seriesList, GenericSeries{
+					Name:   dataItem.Name,
+					Type:   item.Type,
+					Values: dataItem.Value.values,
 					Label: SeriesLabel{
 						FontStyle: FontStyle{
 							FontColor: ParseColor(item.Label.Color),
@@ -289,9 +289,9 @@ func (esList EChartsSeriesList) ToSeriesList() SeriesList {
 			}
 			continue
 		}
-		seriesList = append(seriesList, Series{
+		seriesList = append(seriesList, GenericSeries{
 			Type: item.Type,
-			Data: sliceConversion(item.Data, func(dataItem EChartsSeriesData) float64 {
+			Values: sliceConversion(item.Data, func(dataItem EChartsSeriesData) float64 {
 				return dataItem.Value.First()
 			}),
 			YAxisIndex: item.YAxisIndex,

--- a/examples/multiple_charts-3/main.go
+++ b/examples/multiple_charts-3/main.go
@@ -60,7 +60,7 @@ func main() {
 					SeriesList: charts.NewSeriesListHorizontalBar([][]float64{
 						{70, 90, 110, 130},
 						{80, 100, 120, 140},
-					}),
+					}).ToGenericSeriesList(),
 					Legend: charts.LegendOption{
 						SeriesNames: []string{
 							"2011", "2012",

--- a/examples/web-1/main.go
+++ b/examples/web-1/main.go
@@ -157,13 +157,13 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 					"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
 				},
 			},
-			SeriesList: charts.NewSeriesListLine([][]float64{
+			SeriesList: charts.NewSeriesListGeneric([][]float64{
 				{120, 132, 101, 134, 90, 230, 210},
 				{220, 182, 191, 234, 290, 330, 310},
 				{150, 232, 201, 154, 190, 330, 410},
 				{320, 332, 301, 334, 390, 330, 320},
 				{820, 932, 901, 934, 1290, 1330, 1320},
-			}),
+			}, charts.ChartTypeLine),
 		},
 		// temperature line chart
 		{
@@ -187,9 +187,9 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 				},
 				BoundaryGap: charts.Ptr(false),
 			},
-			SeriesList: []charts.Series{
+			SeriesList: []charts.GenericSeries{
 				{
-					Data: []float64{
+					Values: []float64{
 						14, 11, 13, 11, 12, 12, 7,
 					},
 					Type:      charts.ChartTypeLine,
@@ -197,7 +197,7 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 					MarkLine:  charts.NewMarkLine(charts.SeriesMarkDataTypeAverage),
 				},
 				{
-					Data: []float64{
+					Values: []float64{
 						1, -2, 2, 5, 3, 2, 0,
 					},
 					Type:     charts.ChartTypeLine,
@@ -221,9 +221,9 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 			YAxis: []charts.YAxisOption{{
 				Min: charts.Ptr(0.0), // ensure y-axis starts at 0
 			}},
-			SeriesList: charts.NewSeriesListLine([][]float64{
+			SeriesList: charts.NewSeriesListGeneric([][]float64{
 				{120, 132, 101, 134, 90, 230, 210},
-			}),
+			}, charts.ChartTypeLine),
 			FillArea: charts.Ptr(true),
 		},
 		// histogram
@@ -243,15 +243,15 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 				},
 				Icon: charts.IconRect,
 			},
-			SeriesList: []charts.Series{
+			SeriesList: []charts.GenericSeries{
 				{
-					Data: []float64{
+					Values: []float64{
 						120, 200, 150, 80, 70, 110, 130,
 					},
 					Type: charts.ChartTypeBar,
 				},
 				{
-					Data: []float64{
+					Values: []float64{
 						100, 190, 230, 140, 100, 200, 180,
 					},
 					Type: charts.ChartTypeBar,
@@ -285,10 +285,10 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 					},
 				},
 			},
-			SeriesList: charts.NewSeriesListHorizontalBar([][]float64{
+			SeriesList: charts.NewSeriesListGeneric([][]float64{
 				{18203, 23489, 29034, 104970, 131744, 630230},
 				{19325, 23438, 31000, 121594, 134141, 681807},
-			}),
+			}, charts.ChartTypeHorizontalBar),
 		},
 		// histogram+marker
 		{
@@ -309,10 +309,10 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 					"Rainfall", "Evaporation",
 				},
 			},
-			SeriesList: []charts.Series{
+			SeriesList: []charts.GenericSeries{
 				{
 					Type: charts.ChartTypeBar,
-					Data: []float64{
+					Values: []float64{
 						2.0, 4.9, 7.0, 23.2, 25.6, 76.7, 135.6, 162.2, 32.6, 20.0, 6.4, 3.3,
 					},
 					MarkPoint: charts.NewMarkPoint(
@@ -325,7 +325,7 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 				},
 				{
 					Type: charts.ChartTypeBar,
-					Data: []float64{
+					Values: []float64{
 						2.6, 5.9, 9.0, 26.4, 28.7, 70.7, 175.6, 182.2, 48.7, 18.8, 6.0, 2.3,
 					},
 					MarkPoint: charts.NewMarkPoint(
@@ -365,12 +365,12 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 					AxisColor: charts.ColorRGB(250, 200, 88),
 				},
 			},
-			SeriesList: append(charts.NewSeriesListBar([][]float64{
+			SeriesList: append(charts.NewSeriesListGeneric([][]float64{
 				{2.0, 4.9, 7.0, 23.2, 25.6, 76.7, 135.6, 162.2, 32.6, 20.0, 6.4, 3.3},
 				{2.6, 5.9, 9.0, 26.4, 28.7, 70.7, 175.6, 182.2, 48.7, 18.8, 6.0, 2.3},
-			}), charts.Series{
+			}, charts.ChartTypeBar), charts.GenericSeries{
 				Type: charts.ChartTypeLine,
-				Data: []float64{
+				Values: []float64{
 					2.0, 2.2, 3.3, 4.5, 6.3, 10.2, 20.3, 23.4, 23.0, 16.5, 12.0, 6.2,
 				},
 				YAxisIndex: 1,
@@ -396,7 +396,7 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 				1048, 735, 580, 484, 300,
 			}, charts.PieSeriesOption{
 				Radius: "35%",
-			}),
+			}).ToGenericSeriesList(),
 		},
 		// radar chart
 		{
@@ -436,10 +436,10 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 					Max:  25000,
 				},
 			},
-			SeriesList: charts.NewSeriesListRadar([][]float64{
+			SeriesList: charts.NewSeriesListGeneric([][]float64{
 				{4200, 3000, 20000, 35000, 50000, 18000},
 				{5000, 14000, 28000, 26000, 42000, 21000},
-			}),
+			}, charts.ChartTypeRadar),
 		},
 		// funnel chart
 		{
@@ -451,31 +451,31 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 					"Show", "Click", "Visit", "Inquiry", "Order",
 				},
 			},
-			SeriesList: []charts.Series{
+			SeriesList: []charts.GenericSeries{
 				{
-					Type: charts.ChartTypeFunnel,
-					Name: "Show",
-					Data: []float64{100},
+					Type:   charts.ChartTypeFunnel,
+					Name:   "Show",
+					Values: []float64{100},
 				},
 				{
-					Type: charts.ChartTypeFunnel,
-					Name: "Click",
-					Data: []float64{80},
+					Type:   charts.ChartTypeFunnel,
+					Name:   "Click",
+					Values: []float64{80},
 				},
 				{
-					Type: charts.ChartTypeFunnel,
-					Name: "Visit",
-					Data: []float64{60},
+					Type:   charts.ChartTypeFunnel,
+					Name:   "Visit",
+					Values: []float64{60},
 				},
 				{
-					Type: charts.ChartTypeFunnel,
-					Name: "Inquiry",
-					Data: []float64{40},
+					Type:   charts.ChartTypeFunnel,
+					Name:   "Inquiry",
+					Values: []float64{40},
 				},
 				{
-					Type: charts.ChartTypeFunnel,
-					Name: "Order",
-					Data: []float64{20},
+					Type:   charts.ChartTypeFunnel,
+					Name:   "Order",
+					Values: []float64{20},
 				},
 			},
 		},
@@ -507,14 +507,14 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 				},
 			},
 			SeriesList: append(
-				charts.NewSeriesListLine([][]float64{
+				charts.NewSeriesListGeneric([][]float64{
 					{56.5, 82.1, 88.7, 70.1, 53.4, 85.1},
 					{51.1, 51.4, 55.1, 53.3, 73.8, 68.7},
-				}),
-				charts.NewSeriesListBar([][]float64{
+				}, charts.ChartTypeLine),
+				charts.NewSeriesListGeneric([][]float64{
 					{40.1, 62.2, 69.5, 36.4, 45.2, 32.5},
 					{25.2, 37.1, 41.2, 18, 33.9, 49.1},
-				})...),
+				}, charts.ChartTypeBar)...),
 			Children: []charts.ChartOption{
 				{
 					Legend: charts.LegendOption{
@@ -533,7 +533,7 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 						435.9, 354.3, 285.9, 204.5,
 					}, charts.PieSeriesOption{
 						Radius: "35%",
-					}),
+					}).ToGenericSeriesList(),
 				},
 			},
 		},

--- a/funnel_chart_test.go
+++ b/funnel_chart_test.go
@@ -28,7 +28,7 @@ func TestNewFunnelChartOptionWithData(t *testing.T) {
 	opt := NewFunnelChartOptionWithData([]float64{12, 24, 48})
 
 	assert.Len(t, opt.SeriesList, 3)
-	assert.Equal(t, ChartTypeFunnel, opt.SeriesList[0].Type)
+	assert.Equal(t, ChartTypeFunnel, opt.SeriesList[0].getType())
 	assert.Equal(t, defaultPadding, opt.Padding)
 
 	p := NewPainter(PainterOptions{})

--- a/horizontal_bar_chart_test.go
+++ b/horizontal_bar_chart_test.go
@@ -76,7 +76,7 @@ func TestNewHorizontalBarChartOptionWithData(t *testing.T) {
 	})
 
 	assert.Len(t, opt.SeriesList, 2)
-	assert.Equal(t, ChartTypeHorizontalBar, opt.SeriesList[0].Type)
+	assert.Equal(t, ChartTypeHorizontalBar, opt.SeriesList[0].getType())
 	assert.Equal(t, defaultPadding, opt.Padding)
 
 	p := NewPainter(PainterOptions{})

--- a/line_chart.go
+++ b/line_chart.go
@@ -29,9 +29,9 @@ func NewLineChartOptionWithData(data [][]float64) LineChartOption {
 		Theme:      GetDefaultTheme(),
 		Font:       GetDefaultFont(),
 		XAxis: XAxisOption{
-			Labels: make([]string, sl.getMaxDataCount(ChartTypeLine)),
+			Labels: make([]string, getSeriesMaxDataCount(sl)),
 		},
-		YAxis:          make([]YAxisOption, sl.getYAxisCount()),
+		YAxis:          make([]YAxisOption, getSeriesYAxisCount(sl)),
 		ValueFormatter: defaultValueFormatter,
 	}
 }
@@ -43,8 +43,8 @@ type LineChartOption struct {
 	Padding Box
 	// Font is the font used to render the chart.
 	Font *truetype.Font
-	// SeriesList provides the data series.
-	SeriesList SeriesList
+	// SeriesList provides the data population for the chart, typically constructed using NewSeriesListLine.
+	SeriesList LineSeriesList
 	// StackSeries if set to *true the lines will be layered over each other, with the last series value representing
 	// the sum of all the values. Enabling this will also enable FillArea (which until v0.5 can't be disabled).
 	// Some options will be ignored when StackedSeries is enabled, this includes StrokeSmoothingTension.
@@ -80,7 +80,7 @@ type LineChartOption struct {
 
 const showSymbolDefaultThreshold = 100
 
-func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (Box, error) {
+func (l *lineChart) render(result *defaultRenderResult, seriesList LineSeriesList) (Box, error) {
 	p := l.p
 	opt := l.opt
 	seriesCount := len(seriesList)
@@ -111,7 +111,7 @@ func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (
 	}
 	xDivideValues := autoDivide(seriesPainter.Width(), xDivideCount)
 	xValues := make([]int, len(xDivideValues)-1)
-	dataCount := seriesList.getMaxDataCount(ChartTypeLine)
+	dataCount := getSeriesMaxDataCount(seriesList)
 	// accumulatedValues is used for stacking: it holds the summed data values at each X index
 	var accumulatedValues []float64
 	if stackedSeries {
@@ -141,21 +141,21 @@ func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (
 	markLinePainter := newMarkLinePainter(seriesPainter)
 	rendererList := []renderer{markPointPainter, markLinePainter}
 
-	seriesNames := seriesList.Names()
+	seriesNames := seriesList.names()
 	var priorSeriesPoints []Point
 	for index := range seriesList {
 		series := seriesList[index]
 		stackSeries := stackedSeries && series.YAxisIndex == 0
 		seriesColor := opt.Theme.GetSeriesColor(index)
 		yRange := result.axisRanges[series.YAxisIndex]
-		points := make([]Point, len(series.Data))
+		points := make([]Point, len(series.Values))
 		var labelPainter *seriesLabelPainter
 		if flagIs(true, series.Label.Show) {
 			labelPainter = newSeriesLabelPainter(seriesPainter, seriesNames, series.Label, opt.Theme, opt.Font)
 			rendererList = append(rendererList, labelPainter)
 		}
 
-		for i, item := range series.Data {
+		for i, item := range series.Values {
 			if item == GetNullValue() {
 				points[i] = Point{X: xValues[i], Y: math.MaxInt32}
 			} else if stackSeries {
@@ -251,7 +251,7 @@ func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (
 		var globalSeriesData []float64 // lazily initialized
 		if series.MarkLine.GlobalLine && stackSeries && index == seriesCount-1 {
 			if globalSeriesData == nil {
-				globalSeriesData = seriesList.makeSumSeries(ChartTypeLine, series.YAxisIndex).Data
+				globalSeriesData = sumSeriesData(seriesList, series.YAxisIndex)
 			}
 			markLinePainter.add(markLineRenderOption{
 				fillColor:             defaultGlobalMarkFillColor,
@@ -259,7 +259,7 @@ func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (
 				strokeColor:           defaultGlobalMarkFillColor,
 				font:                  opt.Font,
 				markline:              series.MarkLine,
-				seriesData:            globalSeriesData,
+				seriesValues:          globalSeriesData,
 				axisRange:             yRange,
 				valueFormatterDefault: markLineValueFormatter,
 			})
@@ -271,21 +271,21 @@ func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (
 				strokeColor:           seriesColor,
 				font:                  opt.Font,
 				markline:              series.MarkLine,
-				seriesData:            series.Data,
+				seriesValues:          series.Values,
 				axisRange:             yRange,
 				valueFormatterDefault: markLineValueFormatter,
 			})
 		}
 		if series.MarkPoint.GlobalPoint && stackSeries && index == seriesCount-1 {
 			if globalSeriesData == nil {
-				globalSeriesData = seriesList.makeSumSeries(ChartTypeLine, series.YAxisIndex).Data
+				globalSeriesData = sumSeriesData(seriesList, series.YAxisIndex)
 			}
 			markPointPainter.add(markPointRenderOption{
 				fillColor:             defaultGlobalMarkFillColor,
 				font:                  opt.Font,
 				points:                points,
 				markpoint:             series.MarkPoint,
-				seriesData:            globalSeriesData,
+				seriesValues:          globalSeriesData,
 				valueFormatterDefault: markPointValueFormatter,
 				seriesLabelPainter:    labelPainter,
 			})
@@ -295,7 +295,7 @@ func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (
 				font:                  opt.Font,
 				points:                points,
 				markpoint:             series.MarkPoint,
-				seriesData:            series.Data,
+				seriesValues:          series.Values,
 				valueFormatterDefault: markPointValueFormatter,
 				seriesLabelPainter:    labelPainter,
 			})
@@ -342,6 +342,5 @@ func (l *lineChart) Render() (Box, error) {
 	if err != nil {
 		return BoxZero, err
 	}
-	seriesList := opt.SeriesList.Filter(ChartTypeLine)
-	return l.render(renderResult, seriesList)
+	return l.render(renderResult, opt.SeriesList)
 }

--- a/line_chart_test.go
+++ b/line_chart_test.go
@@ -120,7 +120,7 @@ func TestNewLineChartOptionWithData(t *testing.T) {
 	})
 
 	assert.Len(t, opt.SeriesList, 2)
-	assert.Equal(t, ChartTypeLine, opt.SeriesList[0].Type)
+	assert.Equal(t, ChartTypeLine, opt.SeriesList[0].getType())
 	assert.Len(t, opt.YAxis, 1)
 	assert.Equal(t, defaultPadding, opt.Padding)
 
@@ -502,7 +502,7 @@ func TestLineChart(t *testing.T) {
 			name: "line_gap",
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
-				opt.SeriesList[0].Data[3] = GetNullValue()
+				opt.SeriesList[0].Values[3] = GetNullValue()
 				return opt
 			},
 			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><text x=\"10\" y=\"17\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.44k</text><text x=\"10\" y=\"55\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.28k</text><text x=\"10\" y=\"94\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.12k</text><text x=\"22\" y=\"133\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">960</text><text x=\"22\" y=\"172\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">800</text><text x=\"22\" y=\"211\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">640</text><text x=\"22\" y=\"250\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">480</text><text x=\"22\" y=\"289\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">320</text><text x=\"22\" y=\"328\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">160</text><text x=\"40\" y=\"367\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">0</text><path  d=\"M 59 10\nL 590 10\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 48\nL 590 48\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 87\nL 590 87\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 126\nL 590 126\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 165\nL 590 165\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 204\nL 590 204\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 243\nL 590 243\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 282\nL 590 282\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 321\nL 590 321\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 96 331\nL 172 328\nL 248 336\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 400 339\nL 476 305\nL 552 309\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 96 161\nL 172 134\nL 248 142\nL 324 133\nL 400 47\nL 476 37\nL 552 40\" style=\"stroke-width:2;stroke:rgb(145,204,117);fill:none\"/></svg>",
@@ -511,8 +511,8 @@ func TestLineChart(t *testing.T) {
 			name: "line_gap_dot",
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
-				opt.SeriesList[0].Data[3] = GetNullValue()
-				opt.SeriesList[0].Data[5] = GetNullValue()
+				opt.SeriesList[0].Values[3] = GetNullValue()
+				opt.SeriesList[0].Values[5] = GetNullValue()
 				return opt
 			},
 			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><text x=\"10\" y=\"17\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.44k</text><text x=\"10\" y=\"55\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.28k</text><text x=\"10\" y=\"94\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.12k</text><text x=\"22\" y=\"133\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">960</text><text x=\"22\" y=\"172\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">800</text><text x=\"22\" y=\"211\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">640</text><text x=\"22\" y=\"250\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">480</text><text x=\"22\" y=\"289\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">320</text><text x=\"22\" y=\"328\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">160</text><text x=\"40\" y=\"367\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">0</text><path  d=\"M 59 10\nL 590 10\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 48\nL 590 48\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 87\nL 590 87\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 126\nL 590 126\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 165\nL 590 165\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 204\nL 590 204\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 243\nL 590 243\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 282\nL 590 282\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 321\nL 590 321\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 96 331\nL 172 328\nL 248 336\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><circle cx=\"400\" cy=\"339\" r=\"2\" style=\"stroke:none;fill:none\"/><circle cx=\"552\" cy=\"309\" r=\"2\" style=\"stroke:none;fill:none\"/><path  d=\"M 96 161\nL 172 134\nL 248 142\nL 324 133\nL 400 47\nL 476 37\nL 552 40\" style=\"stroke-width:2;stroke:rgb(145,204,117);fill:none\"/></svg>",
@@ -521,7 +521,7 @@ func TestLineChart(t *testing.T) {
 			name: "line_gap_fill_area",
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
-				opt.SeriesList[0].Data[3] = GetNullValue()
+				opt.SeriesList[0].Values[3] = GetNullValue()
 				opt.FillArea = Ptr(true)
 				return opt
 			},
@@ -531,9 +531,9 @@ func TestLineChart(t *testing.T) {
 			name: "line_gap_start_fill_area",
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
-				opt.SeriesList[0].Data[0] = GetNullValue()
-				opt.SeriesList[0].Data[1] = GetNullValue()
-				opt.SeriesList[1].Data[0] = GetNullValue()
+				opt.SeriesList[0].Values[0] = GetNullValue()
+				opt.SeriesList[0].Values[1] = GetNullValue()
+				opt.SeriesList[1].Values[0] = GetNullValue()
 				opt.FillArea = Ptr(true)
 				return opt
 			},
@@ -544,7 +544,7 @@ func TestLineChart(t *testing.T) {
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
 				opt.StrokeSmoothingTension = 0.8
-				opt.SeriesList[0].Data[3] = GetNullValue()
+				opt.SeriesList[0].Values[3] = GetNullValue()
 				return opt
 			},
 			result: "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><text x=\"10\" y=\"17\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.44k</text><text x=\"10\" y=\"55\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.28k</text><text x=\"10\" y=\"94\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">1.12k</text><text x=\"22\" y=\"133\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">960</text><text x=\"22\" y=\"172\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">800</text><text x=\"22\" y=\"211\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">640</text><text x=\"22\" y=\"250\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">480</text><text x=\"22\" y=\"289\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">320</text><text x=\"22\" y=\"328\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">160</text><text x=\"40\" y=\"367\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">0</text><path  d=\"M 59 10\nL 590 10\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 48\nL 590 48\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 87\nL 590 87\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 126\nL 590 126\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 165\nL 590 165\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 204\nL 590 204\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 243\nL 590 243\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 282\nL 590 282\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 59 321\nL 590 321\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 96 331\nQ172,328 202,331\nQ172,328 248,336\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 400 339\nQ476,305 506,306\nQ476,305 552,309\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 96 161\nQ172,134 202,137\nQ248,142 278,138\nQ324,133 354,98\nQ400,47 430,43\nQ476,37 506,38\nQ476,37 552,40\" style=\"stroke-width:2;stroke:rgb(145,204,117);fill:none\"/></svg>",
@@ -554,7 +554,7 @@ func TestLineChart(t *testing.T) {
 			makeOptions: func() LineChartOption {
 				opt := makeMinimalLineChartOption()
 				opt.StrokeSmoothingTension = 0.8
-				opt.SeriesList[0].Data[3] = GetNullValue()
+				opt.SeriesList[0].Values[3] = GetNullValue()
 				opt.FillArea = Ptr(true)
 				return opt
 			},

--- a/mark_line.go
+++ b/mark_line.go
@@ -40,7 +40,7 @@ type markLineRenderOption struct {
 	fontColor             Color
 	strokeColor           Color
 	font                  *truetype.Font
-	seriesData            []float64
+	seriesValues          []float64
 	markline              SeriesMarkLine
 	axisRange             axisRange
 	valueFormatterDefault ValueFormatter
@@ -52,7 +52,7 @@ func (m *markLinePainter) Render() (Box, error) {
 		if len(opt.markline.Data) == 0 {
 			continue
 		}
-		summary := summarizePopulationData(opt.seriesData)
+		summary := summarizePopulationData(opt.seriesValues)
 		fontStyle := FontStyle{
 			Font:      getPreferredFont(opt.font),
 			FontColor: opt.fontColor,

--- a/mark_line_test.go
+++ b/mark_line_test.go
@@ -18,10 +18,10 @@ func TestMarkLine(t *testing.T) {
 			render: func(p *Painter) ([]byte, error) {
 				markLine := newMarkLinePainter(p)
 				markLine.add(markLineRenderOption{
-					fillColor:   ColorBlack,
-					fontColor:   ColorBlack,
-					strokeColor: ColorBlack,
-					seriesData:  []float64{1, 2, 3},
+					fillColor:    ColorBlack,
+					fontColor:    ColorBlack,
+					strokeColor:  ColorBlack,
+					seriesValues: []float64{1, 2, 3},
 					markline: NewMarkLine(
 						SeriesMarkDataTypeMax,
 						SeriesMarkDataTypeAverage,

--- a/mark_point.go
+++ b/mark_point.go
@@ -33,7 +33,7 @@ func (m *markPointPainter) add(opt markPointRenderOption) {
 type markPointRenderOption struct {
 	fillColor             Color
 	font                  *truetype.Font
-	seriesData            []float64
+	seriesValues          []float64
 	markpoint             SeriesMarkPoint
 	seriesLabelPainter    *seriesLabelPainter
 	points                []Point
@@ -54,7 +54,7 @@ func (m *markPointPainter) Render() (Box, error) {
 			continue
 		}
 		points := opt.points
-		summary := summarizePopulationData(opt.seriesData)
+		summary := summarizePopulationData(opt.seriesValues)
 		symbolSize := opt.markpoint.SymbolSize
 		if symbolSize == 0 {
 			symbolSize = 28

--- a/mark_point_test.go
+++ b/mark_point_test.go
@@ -18,9 +18,9 @@ func TestMarkPoint(t *testing.T) {
 			render: func(p *Painter) ([]byte, error) {
 				markPoint := newMarkPointPainter(p)
 				markPoint.add(markPointRenderOption{
-					fillColor:  ColorBlack,
-					seriesData: []float64{1, 2, 3},
-					markpoint:  NewMarkPoint(SeriesMarkDataTypeMax),
+					fillColor:    ColorBlack,
+					seriesValues: []float64{1, 2, 3},
+					markpoint:    NewMarkPoint(SeriesMarkDataTypeMax),
 					points: []Point{
 						{X: 10, Y: 10},
 						{X: 30, Y: 30},

--- a/pie_chart_test.go
+++ b/pie_chart_test.go
@@ -34,7 +34,7 @@ func TestNewPieChartOptionWithData(t *testing.T) {
 	opt := NewPieChartOptionWithData([]float64{12, 24, 48})
 
 	assert.Len(t, opt.SeriesList, 3)
-	assert.Equal(t, ChartTypePie, opt.SeriesList[0].Type)
+	assert.Equal(t, ChartTypePie, opt.SeriesList[0].getType())
 	assert.Equal(t, defaultPadding, opt.Padding)
 
 	p := NewPainter(PainterOptions{})

--- a/radar_chart.go
+++ b/radar_chart.go
@@ -45,14 +45,16 @@ type RadarChartOption struct {
 	Padding Box
 	// Font is the font used to render the chart.
 	Font *truetype.Font
-	// SeriesList provides the data series.
-	SeriesList SeriesList
+	// SeriesList provides the data population for the chart, typically constructed using NewSeriesListRadar.
+	SeriesList RadarSeriesList
 	// Title are options for rendering the title.
 	Title TitleOption
 	// Legend are options for the data legend.
 	Legend LegendOption
 	// RadarIndicators provides the radar indicator list.
 	RadarIndicators []RadarIndicator
+	// Radius for radar e.g.: 40%, default is "40%"
+	Radius string
 	// ValueFormatter defines how float values should be rendered to strings, notably for series labels.
 	ValueFormatter ValueFormatter
 	// backgroundIsFilled is set to true if the background is filled.
@@ -82,7 +84,7 @@ func newRadarChart(p *Painter, opt RadarChartOption) *radarChart {
 	}
 }
 
-func (r *radarChart) render(result *defaultRenderResult, seriesList SeriesList) (Box, error) {
+func (r *radarChart) render(result *defaultRenderResult, seriesList RadarSeriesList) (Box, error) {
 	opt := r.opt
 	indicators := opt.RadarIndicators
 	sides := len(indicators)
@@ -93,7 +95,7 @@ func (r *radarChart) render(result *defaultRenderResult, seriesList SeriesList) 
 	}
 	maxValues := make([]float64, len(indicators))
 	for _, series := range seriesList {
-		for index, item := range series.Data {
+		for index, item := range series.Values {
 			if index < len(maxValues) && item > maxValues[index] {
 				maxValues[index] = item
 			}
@@ -105,20 +107,13 @@ func (r *radarChart) render(result *defaultRenderResult, seriesList SeriesList) 
 		}
 	}
 
-	var radiusValue string
-	for _, series := range seriesList {
-		if series.Radius != "" {
-			radiusValue = series.Radius
-		}
-	}
-
 	seriesPainter := result.seriesPainter
 	theme := opt.Theme
 
 	cx := seriesPainter.Width() >> 1
 	cy := seriesPainter.Height() >> 1
 	diameter := chartdraw.MinInt(seriesPainter.Width(), seriesPainter.Height())
-	radius := getRadius(float64(diameter), radiusValue)
+	radius := getRadius(float64(diameter), opt.Radius)
 
 	divideCount := 5
 	divideRadius := float64(int(radius / float64(divideCount)))
@@ -185,7 +180,7 @@ func (r *radarChart) render(result *defaultRenderResult, seriesList SeriesList) 
 		valueFormatter := getPreferredValueFormatter(series.Label.ValueFormatter, opt.ValueFormatter,
 			radarDefaultValueFormatter)
 		linePoints := make([]Point, 0, maxCount)
-		for j, item := range series.Data {
+		for j, item := range series.Values {
 			if j >= maxCount {
 				continue
 			}
@@ -210,8 +205,8 @@ func (r *radarChart) render(result *defaultRenderResult, seriesList SeriesList) 
 		dotWith := defaultDotWidth
 		for index, point := range linePoints {
 			seriesPainter.Circle(dotWith, point.X, point.Y, dotFillColor, color, defaultStrokeWidth)
-			if flagIs(true, series.Label.Show) && index < len(series.Data) {
-				valueStr := valueFormatter(series.Data[index])
+			if flagIs(true, series.Label.Show) && index < len(series.Values) {
+				valueStr := valueFormatter(series.Values[index])
 				b := seriesPainter.MeasureText(valueStr, 0, fontStyle)
 				seriesPainter.Text(valueStr, point.X-b.Width()/2, point.Y, 0, fontStyle)
 			}
@@ -247,6 +242,5 @@ func (r *radarChart) Render() (Box, error) {
 	if err != nil {
 		return BoxZero, err
 	}
-	seriesList := opt.SeriesList.Filter(ChartTypeRadar)
-	return r.render(renderResult, seriesList)
+	return r.render(renderResult, opt.SeriesList)
 }

--- a/radar_chart_test.go
+++ b/radar_chart_test.go
@@ -52,7 +52,7 @@ func TestNewRadarChartOptionWithData(t *testing.T) {
 	})
 
 	assert.Len(t, opt.SeriesList, 2)
-	assert.Equal(t, ChartTypeRadar, opt.SeriesList[0].Type)
+	assert.Equal(t, ChartTypeRadar, opt.SeriesList[0].getType())
 	assert.Equal(t, defaultPadding, opt.Padding)
 
 	p := NewPainter(PainterOptions{})

--- a/series_test.go
+++ b/series_test.go
@@ -1,92 +1,129 @@
 package charts
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func TestNewSeriesListDataFromValues(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, SeriesList{
-		{
-			Type: ChartTypeBar,
-			Data: []float64{1.0},
-		},
-	}, NewSeriesListBar([][]float64{
-		{1},
-	}))
-}
 
 func TestSeriesLists(t *testing.T) {
 	t.Parallel()
 
-	seriesList := NewSeriesListBar([][]float64{
+	values := [][]float64{
 		{1, 2},
 		{10},
 		{1, 2, 3, 4, 5, 6, 7, 8, 9},
-	})
+	}
+	for i, tc := range []string{ChartTypeLine, ChartTypeBar, ChartTypeHorizontalBar} {
+		t.Run(strconv.Itoa(i)+"-"+tc, func(t *testing.T) {
+			var seriesList seriesList
+			switch tc { // switch case to ensure chart type and generic type match expectations
+			case ChartTypeLine:
+				seriesList = NewSeriesListLine(values)
+				assert.Len(t, filterSeriesList[LineSeriesList](seriesList, ChartTypeLine), 3)
+				assert.Empty(t, filterSeriesList[BarSeriesList](seriesList, ChartTypeBar))
+			case ChartTypeBar:
+				seriesList = NewSeriesListBar(values)
+				assert.Len(t, filterSeriesList[BarSeriesList](seriesList, ChartTypeBar), 3)
+				assert.Empty(t, filterSeriesList[LineSeriesList](seriesList, ChartTypeLine))
+			case ChartTypeHorizontalBar:
+				seriesList = NewSeriesListHorizontalBar(values)
+				assert.Len(t, filterSeriesList[HorizontalBarSeriesList](seriesList, ChartTypeHorizontalBar), 3)
+				assert.Empty(t, filterSeriesList[LineSeriesList](seriesList, ChartTypeLine))
+			default:
+				require.Fail(t, "Need to implement chart type test")
+			}
 
-	assert.Len(t, seriesList.Filter(ChartTypeBar), 3)
-	assert.Empty(t, seriesList.Filter(ChartTypeLine))
-
-	min, max, maxSum := seriesList.getMinMaxSumMax(0, true)
-	assert.InDelta(t, float64(12), maxSum, 0)
-	assert.InDelta(t, float64(10), max, 0)
-	assert.InDelta(t, float64(1), min, 0)
+			min, max, maxSum := getSeriesMinMaxSumMax(seriesList, 0, true)
+			assert.InDelta(t, float64(12), maxSum, 0)
+			assert.InDelta(t, float64(10), max, 0)
+			assert.InDelta(t, float64(1), min, 0)
+		})
+	}
 }
 
 func TestSumSeries(t *testing.T) {
 	t.Parallel()
 
-	t.Run("empty", func(t *testing.T) {
-		var sl SeriesList
-		result := sl.SumSeries()
-
-		assert.Equal(t, "", result.Type)
-		assert.Empty(t, result.Data)
-	})
-
-	t.Run("single", func(t *testing.T) {
-		sl := SeriesList{
-			{
-				Type:       ChartTypeLine,
-				Data:       []float64{1.5, 2.5},
-				Name:       "SingleLine",
-				YAxisIndex: 1,
-				Radius:     "50%",
+	type summableSeries interface {
+		SumSeries() []float64
+	}
+	testTypes := []struct {
+		name       string
+		seriesFact func([][]float64) summableSeries
+	}{
+		{
+			name: "line",
+			seriesFact: func(values [][]float64) summableSeries {
+				return NewSeriesListLine(values)
 			},
+		},
+		{
+			name: "bar",
+			seriesFact: func(values [][]float64) summableSeries {
+				return NewSeriesListBar(values)
+			},
+		},
+		{
+			name: "horizontal_bar",
+			seriesFact: func(values [][]float64) summableSeries {
+				return NewSeriesListHorizontalBar(values)
+			},
+		},
+	}
+	tests := []struct {
+		name     string
+		values   [][]float64
+		expected []float64
+	}{
+		{
+			name:     "empty",
+			values:   [][]float64{},
+			expected: []float64{},
+		},
+		{
+			name:     "single",
+			values:   [][]float64{{1.5, 2.5}},
+			expected: []float64{1.5, 2.5},
+		},
+		{
+			name: "multiple",
+			values: [][]float64{
+				{1, 2, 3},
+				{4, 5, 6},
+			},
+			expected: []float64{5, 7, 9},
+		},
+		{
+			name: "unequal_data_length",
+			values: [][]float64{
+				{1, 2},
+				{3, 4, 5},
+			},
+			expected: []float64{4, 6, 5},
+		},
+		{
+			name: "null_values",
+			values: [][]float64{
+				{GetNullValue(), 2, 3},
+				{4, GetNullValue(), 6},
+			},
+			expected: []float64{4, 2, 9},
+		},
+	}
+
+	for _, typeCase := range testTypes {
+		for _, tc := range tests {
+			t.Run(typeCase.name+"-"+tc.name, func(t *testing.T) {
+				series := typeCase.seriesFact(tc.values)
+				result := series.SumSeries()
+
+				assert.Equal(t, tc.expected, result)
+			})
 		}
-
-		result := sl.SumSeries()
-
-		assert.Equal(t, sl[0], result)
-	})
-
-	t.Run("multiple", func(t *testing.T) {
-		sl := NewSeriesListLine([][]float64{
-			{1, 2, 3},
-			{4, 5, 6},
-		})
-
-		result := sl.SumSeries()
-
-		assert.Equal(t, ChartTypeLine, result.Type)
-		assert.Equal(t, []float64{5, 7, 9}, result.Data)
-	})
-
-	t.Run("unequal_data_length", func(t *testing.T) {
-		sl := NewSeriesListLine([][]float64{
-			{1, 2},
-			{3, 4, 5},
-		})
-
-		result := sl.SumSeries()
-
-		assert.Equal(t, ChartTypeLine, result.Type)
-		assert.Equal(t, []float64{4, 6, 5}, result.Data)
-	})
+	}
 }
 
 func TestSeriesSummary(t *testing.T) {
@@ -104,7 +141,7 @@ func TestSeriesSummary(t *testing.T) {
 		assert.Equal(t, populationSummary{
 			MaxIndex: -1,
 			MinIndex: -1,
-		}, (&Series{}).Summary())
+		}, summarizePopulationData(nil))
 	})
 	t.Run("one_value", func(t *testing.T) {
 		assert.Equal(t, populationSummary{
@@ -181,4 +218,82 @@ func TestFormatter(t *testing.T) {
 
 	assert.Equal(t, "10",
 		labelFormatValue([]string{"a", "b"}, "", 0, 10, 0.12))
+}
+
+func BenchmarkGetSeriesYAxisCount(b *testing.B) { // benchmark used to evaluate methods for iterating the series
+	nameCount := 100
+	seriesList := make(LineSeriesList, nameCount)
+	for i := 0; i < nameCount; i++ {
+		seriesList[i] = LineSeries{}
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = getSeriesYAxisCount(seriesList)
+	}
+}
+
+func BenchmarkGetSeriesMinMaxSumMax(b *testing.B) { // benchmark used to evaluate methods for iterating the series
+	seriesCount := 100
+	seriesSize := 100
+	seriesList := make(LineSeriesList, seriesCount)
+	for i := 0; i < seriesCount; i++ {
+		data := make([]float64, seriesSize)
+		for si := 0; si < seriesSize; si++ {
+			if si+1%10 == 0 {
+				data[si] = GetNullValue()
+			} else {
+				data[si] = float64(si)
+			}
+		}
+		seriesList[i] = LineSeries{
+			Values: data,
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, _, _ = getSeriesMinMaxSumMax(seriesList, 0, true)
+	}
+}
+
+func BenchmarkSumSeries(b *testing.B) { // benchmark used to evaluate methods for iterating the series
+	seriesCount := 100
+	seriesSize := 100
+	seriesList := make(LineSeriesList, seriesCount)
+	for i := 0; i < seriesCount; i++ {
+		seriesList[i] = LineSeries{
+			Values: make([]float64, seriesSize),
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = seriesList.SumSeries()
+	}
+}
+
+func BenchmarkSeriesNames(b *testing.B) { // benchmark used to evaluate methods for iterating the series
+	nameCount := 100
+	seriesList := make(LineSeriesList, nameCount)
+	for i := 0; i < nameCount; i++ {
+		seriesList[i] = LineSeries{
+			Name: strconv.Itoa(i),
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = seriesList.names()
+	}
+}
+
+func BenchmarkGetSeriesMaxDataCount(b *testing.B) { // benchmark used to evaluate methods for iterating the series
+	seriesCount := 100
+	seriesList := make(LineSeriesList, seriesCount)
+	for i := 0; i < seriesCount; i++ {
+		seriesList[i] = LineSeries{
+			Values: make([]float64, i),
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = getSeriesMaxDataCount(seriesList)
+	}
 }


### PR DESCRIPTION
For ease of adoption, it's important that chart options are obvious and functional.  Having extra fields in the struct which only work under certain chart types or conditions can make it difficult to adopt our library. `Series` is a notable exception of this design pattern as it contains:
* MarkLine & MarkPoint - currently only supported on Line and Bar charts (Horizontal Bar charts will be a future feature expansion)
* Radius - currently only supported on Pie charts and Radar charts (partially, Radar charts do not support per-series radius differences)

In order to make the Series struct able to be flexible to match exactly the chart type, this change creates a `XxxSeries` struct for each chart type. This has the added benefit of removing the `Type` field, since the type is defined through the Series struct itself.

## Negatives:
* This introduces a lot of code in `series.go`, with many small but often mostly duplicate implementations to just handle the different types
* Use of `ChartOptions` is slightly worse - Since this struct is generic for all chart types the former `Series` struct was a nice fit. We introduced `GeneralSeries` which maintains the flexibility the old struct had.  It needs to be constructed through `NewSeriesListGeneral` or through the former methods and then invoking `.ToGeneralSeries()` in order to convert the chart specific series to the general one.

## Alternatives considered:
These chart configuration options could be moved from the `Series` struct into the specific Chart Option struct.  This provides an easy way to discover these options (vs being multiple structs deep). It also allows us to create MarkLines and other features that don't have to be correlated to a specific series (e.g. our Global feature for MarkLine and MarkPoint's).

The challenge with this is that in most cases these fields need to be correlated to a specific series.  Which introduces:
* The need to reference the series by index (which could change depending on the order of the Legend names)
* Or the need to reference by the series name (not often set)

If we did adopt this we could easily add an `SeriesIndex` field in subsequent structs (e.g. `SeriesMarkLine`), but this would require this additional field to be manually set.

We could alternatively use a map with the key being the series index, this would force a clear choice but will require the Options struct map's to be initialized.

---

Overall I want to consider this for v0.5 because I believe it produces an external API that is easier to understand and adopt for new users, with the primary burden being internal complexity.  However I am opening this as second PR so I can get some specific review and consideration around this very significant API change.