### PR TITLE
tests: Split `main` Push and Pull Requests tests into two workflows

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -1,0 +1,10 @@
+name: Tests - Main Push
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/tests-workflow.yml
+

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -1,0 +1,9 @@
+name: Tests - Pull Request
+
+on:
+  pull_request:
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/tests-workflow.yml
+

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -1,9 +1,7 @@
-name: Test
+name: Tests
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
+  workflow_call:
 
 jobs:
   lint-and-tidy:


### PR DESCRIPTION
This splits the workflow into two, this way the `README` test badge wont be marked as failing due to failing within a pull request.