### PR TITLE
Fix FormatValueHumanizeShort negative handling

### DIFF
--- a/util.go
+++ b/util.go
@@ -237,9 +237,7 @@ func normalizeAngle(radians float64) float64 {
 // returning a human friendly number string including commas. If the value is over 1,000 it will be reduced to a
 // shorter version with the appropriate k, M, G, T suffix.
 func FormatValueHumanizeShort(value float64, decimals int, ensureTrailingZeros bool) string {
-	// Handle negative values by delegating to the positive case and
-	// then re-applying the sign.  This mirrors the behaviour of
-	// FormatValueHumanize which already handles negative numbers.
+	// Handle negative values by delegating to the positive case and then re-applying the sign
 	if value < 0 {
 		return "-" + FormatValueHumanizeShort(-value, decimals, ensureTrailingZeros)
 	}

--- a/util.go
+++ b/util.go
@@ -237,6 +237,13 @@ func normalizeAngle(radians float64) float64 {
 // returning a human friendly number string including commas. If the value is over 1,000 it will be reduced to a
 // shorter version with the appropriate k, M, G, T suffix.
 func FormatValueHumanizeShort(value float64, decimals int, ensureTrailingZeros bool) string {
+	// Handle negative values by delegating to the positive case and
+	// then re-applying the sign.  This mirrors the behaviour of
+	// FormatValueHumanize which already handles negative numbers.
+	if value < 0 {
+		return "-" + FormatValueHumanizeShort(-value, decimals, ensureTrailingZeros)
+	}
+
 	if value >= tValue {
 		return FormatValueHumanize(value/tValue, decimals, ensureTrailingZeros) + "T"
 	} else if value >= gValue {

--- a/util_test.go
+++ b/util_test.go
@@ -43,6 +43,15 @@ func TestFormatValueHumanizeShort(t *testing.T) {
 	assert.Equal(t, "1.22k", FormatValueHumanizeShort(1216.121, 2, false))
 	assert.Equal(t, "1.2M", FormatValueHumanizeShort(1200000.121, 2, false))
 	assert.Equal(t, "1.20M", FormatValueHumanizeShort(1200000.121, 2, true))
+
+	// Verify negative number handling matches positive formatting with a
+	// leading minus sign.
+	assert.Equal(t, "-1", FormatValueHumanizeShort(-1.2, 0, false))
+	assert.Equal(t, "-1.2", FormatValueHumanizeShort(-1.2, 2, false))
+	assert.Equal(t, "-1.21", FormatValueHumanizeShort(-1.21231, 2, false))
+	assert.Equal(t, "-1.2k", FormatValueHumanizeShort(-1200.121, 2, false))
+	assert.Equal(t, "-1.20k", FormatValueHumanizeShort(-1200.121, 2, true))
+	assert.Equal(t, "-1.2M", FormatValueHumanizeShort(-1200000.121, 1, false))
 }
 
 func TestFormatValueHumanize(t *testing.T) {

--- a/util_test.go
+++ b/util_test.go
@@ -44,8 +44,6 @@ func TestFormatValueHumanizeShort(t *testing.T) {
 	assert.Equal(t, "1.2M", FormatValueHumanizeShort(1200000.121, 2, false))
 	assert.Equal(t, "1.20M", FormatValueHumanizeShort(1200000.121, 2, true))
 
-	// Verify negative number handling matches positive formatting with a
-	// leading minus sign.
 	assert.Equal(t, "-1", FormatValueHumanizeShort(-1.2, 0, false))
 	assert.Equal(t, "-1.2", FormatValueHumanizeShort(-1.2, 2, false))
 	assert.Equal(t, "-1.21", FormatValueHumanizeShort(-1.21231, 2, false))


### PR DESCRIPTION
## Summary
- handle negative values in `FormatValueHumanizeShort`
- add tests covering negative formatting

## Testing
- `go test ./... -run TestFormatValueHumanizeShort -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6841d34e511883299beff9cf990b5b7b