### PR TITLE
Fix ScaleRow bug in matrix operations

### DIFF
--- a/chartdraw/matrix/matrix.go
+++ b/chartdraw/matrix/matrix.go
@@ -228,7 +228,8 @@ func (m *Matrix) SubMatrix(i, j, rows, cols int) *Matrix {
 // ScaleRow applies a scale to an entire row.
 func (m *Matrix) ScaleRow(row int, scale float64) {
 	startIndex := row * m.stride
-	for i := startIndex; i < m.stride; i++ {
+	endIndex := startIndex + m.stride
+	for i := startIndex; i < endIndex; i++ {
 		m.elements[i] *= scale
 	}
 }

--- a/chartdraw/matrix/matrix_test.go
+++ b/chartdraw/matrix/matrix_test.go
@@ -219,6 +219,22 @@ func TestMatrixSwapRows(t *testing.T) {
 	assert.Equal(t, Vector([]float64{7, 8, 9}), m.Row(2))
 }
 
+func TestMatrixScaleRow(t *testing.T) {
+	t.Parallel()
+
+	m := NewFromArrays([][]float64{
+		{1, 2, 3},
+		{4, 5, 6},
+		{7, 8, 9},
+	})
+
+	m.ScaleRow(1, 2.0)
+
+	assert.Equal(t, Vector([]float64{1, 2, 3}), m.Row(0))
+	assert.Equal(t, Vector([]float64{8, 10, 12}), m.Row(1))
+	assert.Equal(t, Vector([]float64{7, 8, 9}), m.Row(2))
+}
+
 func TestMatrixCopy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- fix `ScaleRow` so it iterates over the whole row
- add `TestMatrixScaleRow` to verify row scaling

## Testing
- `go test ./...`
- `go test ./chartdraw/matrix -run TestMatrixScaleRow -v`


------
https://chatgpt.com/codex/tasks/task_e_68423607b16c83298f9a0aa8882e4b2f