### PR TITLE
Fix handling of empty series for range calculations

### DIFF
--- a/series.go
+++ b/series.go
@@ -1406,6 +1406,12 @@ func getSeriesMinMaxSumMax(sl seriesList, yaxisIndex int, calcSum bool) (float64
 			}
 		}
 	}
+	// If min was not updated then there were no valid data points. Return
+	// zeros to avoid propagating sentinel values like math.MaxFloat64 which
+	// can corrupt downstream range calculations.
+	if min == math.MaxFloat64 && max == -math.MaxFloat64 {
+		return 0, 0, 0
+	}
 	return min, max, maxSum
 }
 

--- a/series_test.go
+++ b/series_test.go
@@ -44,6 +44,22 @@ func TestSeriesLists(t *testing.T) {
 	}
 }
 
+func TestGetSeriesMinMaxSumMaxEmpty(t *testing.T) {
+	t.Parallel()
+
+	empty := NewSeriesListLine([][]float64{{}})
+	min, max, sum := getSeriesMinMaxSumMax(empty, 0, true)
+	assert.InDelta(t, 0.0, min, 0)
+	assert.InDelta(t, 0.0, max, 0)
+	assert.InDelta(t, 0.0, sum, 0)
+
+	nullVals := NewSeriesListLine([][]float64{{GetNullValue(), GetNullValue()}})
+	min, max, sum = getSeriesMinMaxSumMax(nullVals, 0, true)
+	assert.InDelta(t, 0.0, min, 0)
+	assert.InDelta(t, 0.0, max, 0)
+	assert.InDelta(t, 0.0, sum, 0)
+}
+
 func TestSumSeries(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- fix `getSeriesMinMaxSumMax` to return zeros when series data is empty
- add regression tests for empty data handling

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68423b63e3908329833de31cc1e416cb