### PR TITLE
test: Add `chartdraw/drawing` math operation test coverage

### DIFF
--- a/chartdraw/drawing/curve_test.go
+++ b/chartdraw/drawing/curve_test.go
@@ -1,6 +1,7 @@
 package drawing
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,5 +32,36 @@ func TestTraceQuad(t *testing.T) {
 	quad := []float64{10, 20, 20, 20, 20, 10}
 	liner := &mockLine{}
 	TraceQuad(liner, quad, 0.5)
+	assert.NotZero(t, liner.Len())
+}
+
+func TestSubdivideCubic(t *testing.T) {
+	t.Parallel()
+
+	cubic := []float64{0, 0, 0, 1, 1, 1, 1, 0}
+	c1 := make([]float64, 8)
+	c2 := make([]float64, 8)
+	SubdivideCubic(cubic, c1, c2)
+
+	expectC1 := []float64{0, 0, 0, 0.5, 0.25, 0.75, 0.5, 0.75}
+	expectC2 := []float64{0.5, 0.75, 0.75, 0.75, 1, 0.5, 1, 0}
+	assert.InDeltaSlice(t, expectC1, c1, 0.0001)
+	assert.InDeltaSlice(t, expectC2, c2, 0.0001)
+}
+
+func TestTraceCubicAndArc(t *testing.T) {
+	t.Parallel()
+
+	cubic := []float64{0, 0, 0, 1, 1, 1, 1, 0}
+	liner := &mockLine{}
+	TraceCubic(liner, cubic, 0.1)
+	last := liner.inner[len(liner.inner)-1]
+	assert.InDelta(t, 1.0, last.X, 0.0001)
+	assert.InDelta(t, 0.0, last.Y, 0.0001)
+
+	liner = &mockLine{}
+	lx, ly := TraceArc(liner, 0, 0, 1, 1, 0, math.Pi/2, 1)
+	assert.InDelta(t, 0.0, lx, 0.0001)
+	assert.InDelta(t, 1.0, ly, 0.0001)
 	assert.NotZero(t, liner.Len())
 }

--- a/chartdraw/drawing/dasher_test.go
+++ b/chartdraw/drawing/dasher_test.go
@@ -1,0 +1,37 @@
+package drawing
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type recordFlattenerEnd struct {
+	moves []string
+}
+
+func (r *recordFlattenerEnd) MoveTo(x, y float64) {
+	r.moves = append(r.moves, fmt.Sprintf("M%.1f,%.1f", x, y))
+}
+
+func (r *recordFlattenerEnd) LineTo(x, y float64) {
+	r.moves = append(r.moves, fmt.Sprintf("L%.1f,%.1f", x, y))
+}
+
+func (r *recordFlattenerEnd) End() {
+	r.moves = append(r.moves, "E")
+}
+
+func TestDashVertexConverterLineTo(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordFlattenerEnd{}
+	d := NewDashVertexConverter([]float64{2, 2}, 0, rec)
+	d.MoveTo(0, 0)
+	d.LineTo(5, 0)
+	d.End()
+
+	expect := []string{"M0.0,0.0", "L2.0,0.0", "E", "M4.0,0.0", "L5.0,0.0", "E"}
+	assert.Equal(t, expect, rec.moves)
+}

--- a/chartdraw/drawing/line_test.go
+++ b/chartdraw/drawing/line_test.go
@@ -1,0 +1,43 @@
+package drawing
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBresenhamDiagonal(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 5, 5))
+	Bresenham(img, color.White, 0, 0, 4, 4)
+
+	for i := 0; i <= 4; i++ {
+		r, g, b, a := img.At(i, i).RGBA()
+		assert.Equal(t, uint32(0xffff), r)
+		assert.Equal(t, uint32(0xffff), g)
+		assert.Equal(t, uint32(0xffff), b)
+		assert.Equal(t, uint32(0xffff), a)
+	}
+
+	_, _, _, a := img.At(0, 1).RGBA()
+	assert.Equal(t, uint32(0), a)
+}
+
+func TestPolylineBresenham(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 5, 5))
+	PolylineBresenham(img, color.White, 0, 0, 2, 0, 2, 2)
+
+	expected := [][2]int{{0, 0}, {1, 0}, {2, 0}, {2, 1}, {2, 2}}
+	for _, p := range expected {
+		_, _, _, a := img.At(p[0], p[1]).RGBA()
+		assert.Equal(t, uint32(0xffff), a)
+	}
+
+	_, _, _, a := img.At(1, 1).RGBA()
+	assert.Equal(t, uint32(0), a)
+}

--- a/chartdraw/drawing/matrix_test.go
+++ b/chartdraw/drawing/matrix_test.go
@@ -13,8 +13,8 @@ func TestMatrixTransformInverse(t *testing.T) {
 
 	m := NewTranslationMatrix(5, 7)
 	x, y := m.TransformPoint(1, 2)
-	assert.Equal(t, 6.0, x)
-	assert.Equal(t, 9.0, y)
+	assert.InDelta(t, 6.0, x, 0.0)
+	assert.InDelta(t, 9.0, y, 0.0)
 
 	ix, iy := m.InverseTransformPoint(x, y)
 	assert.InDelta(t, 1.0, ix, matrix.DefaultEpsilon)
@@ -40,10 +40,10 @@ func TestMatrixTransformRectangle(t *testing.T) {
 
 	m := NewScaleMatrix(2, 3)
 	x0, y0, x1, y1 := m.TransformRectangle(1, 2, 3, 4)
-	assert.Equal(t, 2.0, x0)
-	assert.Equal(t, 6.0, y0)
-	assert.Equal(t, 6.0, x1)
-	assert.Equal(t, 12.0, y1)
+	assert.InDelta(t, 2.0, x0, 0.0)
+	assert.InDelta(t, 6.0, y0, 0.0)
+	assert.InDelta(t, 6.0, x1, 0.0)
+	assert.InDelta(t, 12.0, y1, 0.0)
 }
 
 func TestMatrixIdentityHelpers(t *testing.T) {
@@ -55,8 +55,8 @@ func TestMatrixIdentityHelpers(t *testing.T) {
 
 	tr := NewTranslationMatrix(2, 3)
 	tx, ty := tr.GetTranslation()
-	assert.Equal(t, 2.0, tx)
-	assert.Equal(t, 3.0, ty)
+	assert.InDelta(t, 2.0, tx, 0.0)
+	assert.InDelta(t, 3.0, ty, 0.0)
 }
 
 func TestMatrixTransformSlice(t *testing.T) {
@@ -86,8 +86,8 @@ func TestMatrixScaleTranslateRotate(t *testing.T) {
 	m := NewIdentityMatrix()
 	m.Scale(2, 3)
 	sx, sy := m.GetScaling()
-	assert.Equal(t, 2.0, sx)
-	assert.Equal(t, 3.0, sy)
+	assert.InDelta(t, 2.0, sx, 0.0)
+	assert.InDelta(t, 3.0, sy, 0.0)
 
 	m.Translate(4, 5)
 	assert.InDeltaSlice(t, []float64{2, 0, 0, 3, 8, 15}, m[:], matrix.DefaultEpsilon)

--- a/chartdraw/drawing/matrix_test.go
+++ b/chartdraw/drawing/matrix_test.go
@@ -1,0 +1,108 @@
+package drawing
+
+import (
+	"math"
+	"testing"
+
+	"github.com/go-analyze/charts/chartdraw/matrix"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatrixTransformInverse(t *testing.T) {
+	t.Parallel()
+
+	m := NewTranslationMatrix(5, 7)
+	x, y := m.TransformPoint(1, 2)
+	assert.Equal(t, 6.0, x)
+	assert.Equal(t, 9.0, y)
+
+	ix, iy := m.InverseTransformPoint(x, y)
+	assert.InDelta(t, 1.0, ix, matrix.DefaultEpsilon)
+	assert.InDelta(t, 2.0, iy, matrix.DefaultEpsilon)
+}
+
+func TestMatrixComposeInverse(t *testing.T) {
+	t.Parallel()
+
+	m := NewScaleMatrix(2, 3)
+	m.Translate(4, 5)
+	m.Rotate(math.Pi / 3)
+
+	inv := m.Copy()
+	inv.Inverse()
+	inv.Compose(m)
+
+	assert.True(t, inv.IsIdentity())
+}
+
+func TestMatrixTransformRectangle(t *testing.T) {
+	t.Parallel()
+
+	m := NewScaleMatrix(2, 3)
+	x0, y0, x1, y1 := m.TransformRectangle(1, 2, 3, 4)
+	assert.Equal(t, 2.0, x0)
+	assert.Equal(t, 6.0, y0)
+	assert.Equal(t, 6.0, x1)
+	assert.Equal(t, 12.0, y1)
+}
+
+func TestMatrixIdentityHelpers(t *testing.T) {
+	t.Parallel()
+
+	id := NewIdentityMatrix()
+	assert.True(t, id.IsTranslation())
+	assert.True(t, id.IsIdentity())
+
+	tr := NewTranslationMatrix(2, 3)
+	tx, ty := tr.GetTranslation()
+	assert.Equal(t, 2.0, tx)
+	assert.Equal(t, 3.0, ty)
+}
+
+func TestMatrixTransformSlice(t *testing.T) {
+	t.Parallel()
+
+	m := NewScaleMatrix(2, 3)
+	m.Translate(4, -5)
+	pts := []float64{1, 2, 3, 4}
+	expect := append([]float64(nil), pts...)
+	m.Transform(pts)
+	m.InverseTransform(pts)
+	assert.InDeltaSlice(t, expect, pts, matrix.DefaultEpsilon)
+}
+
+func TestMatrixVectorTransform(t *testing.T) {
+	t.Parallel()
+
+	m := NewRotationMatrix(math.Pi / 2)
+	vec := []float64{1, 0}
+	m.VectorTransform(vec)
+	assert.InDeltaSlice(t, []float64{0, 1}, vec, matrix.DefaultEpsilon)
+}
+
+func TestMatrixScaleTranslateRotate(t *testing.T) {
+	t.Parallel()
+
+	m := NewIdentityMatrix()
+	m.Scale(2, 3)
+	sx, sy := m.GetScaling()
+	assert.Equal(t, 2.0, sx)
+	assert.Equal(t, 3.0, sy)
+
+	m.Translate(4, 5)
+	assert.InDeltaSlice(t, []float64{2, 0, 0, 3, 8, 15}, m[:], matrix.DefaultEpsilon)
+
+	m.Rotate(math.Pi / 2)
+	expected := Matrix{0, 3, -2, 0, 8, 15}
+	assert.True(t, m.Equals(expected))
+}
+
+func TestMatrixGetScale(t *testing.T) {
+	t.Parallel()
+
+	m := NewScaleMatrix(2, 2)
+	assert.InDelta(t, 2.0, m.GetScale(), matrix.DefaultEpsilon)
+
+	m.Rotate(math.Pi / 4)
+	assert.InDelta(t, 2.0, m.GetScale(), matrix.DefaultEpsilon)
+}

--- a/chartdraw/drawing/path_test.go
+++ b/chartdraw/drawing/path_test.go
@@ -1,0 +1,110 @@
+package drawing
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type recordFlattener struct {
+	moves []string
+}
+
+func (r *recordFlattener) MoveTo(x, y float64) {
+	r.moves = append(r.moves, fmt.Sprintf("M%.1f,%.1f", x, y))
+}
+
+func (r *recordFlattener) LineTo(x, y float64) {
+	r.moves = append(r.moves, fmt.Sprintf("L%.1f,%.1f", x, y))
+}
+
+func (r *recordFlattener) End() {}
+
+func TestPathBasicOps(t *testing.T) {
+	t.Parallel()
+
+	p := &Path{}
+	p.LineTo(1, 2)
+	p.LineTo(3, 4)
+	assert.Equal(t, []PathComponent{MoveToComponent, LineToComponent, LineToComponent}, p.Components)
+	assert.InDeltaSlice(t, []float64{0, 0, 1, 2, 3, 4}, p.Points, 0.0001)
+}
+
+func TestPathArcTo(t *testing.T) {
+	t.Parallel()
+
+	p := &Path{}
+	p.ArcTo(0, 0, 1, 1, 0, math.Pi/2)
+
+	expectX := 0.0
+	expectY := 1.0
+	assert.InDelta(t, expectX, p.x, 0.0001)
+	assert.InDelta(t, expectY, p.y, 0.0001)
+	assert.InDeltaSlice(t, []float64{1, 0, 0, 0, 1, 1, 0, math.Pi / 2}, p.Points, 0.0001)
+	assert.Equal(t, MoveToComponent, p.Components[0])
+	assert.Equal(t, ArcToComponent, p.Components[1])
+}
+
+func TestTransformer(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordFlattener{}
+	tr := Transformer{Tr: NewTranslationMatrix(2, 3), Flattener: rec}
+	tr.MoveTo(1, 1)
+	tr.LineTo(2, 2)
+	tr.End()
+
+	assert.Equal(t, []string{"M3.0,4.0", "L4.0,5.0"}, rec.moves)
+}
+
+func TestPathCurveAndClose(t *testing.T) {
+	t.Parallel()
+
+	p := &Path{}
+	p.QuadCurveTo(1, 1, 2, 2)
+	p.CubicCurveTo(3, 3, 4, 4, 5, 5)
+	p.Close()
+
+	expComp := []PathComponent{MoveToComponent, QuadCurveToComponent, CubicCurveToComponent, CloseComponent}
+	assert.Equal(t, expComp, p.Components)
+	assert.InDeltaSlice(t, []float64{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5}, p.Points, 0.0001)
+	assert.InDelta(t, 5.0, p.x, 0.0001)
+	assert.InDelta(t, 5.0, p.y, 0.0001)
+}
+
+func TestPathCopyClearIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	p := &Path{}
+	p.LineTo(1, 1)
+	copyP := p.Copy()
+
+	p.Clear()
+	assert.True(t, p.IsEmpty())
+	assert.False(t, copyP.IsEmpty())
+
+	p2 := &Path{}
+	assert.True(t, p2.IsEmpty())
+}
+
+func TestPathString(t *testing.T) {
+	t.Parallel()
+
+	p := &Path{}
+	p.MoveTo(0, 0)
+	p.LineTo(1, 1)
+	p.QuadCurveTo(2, 2, 3, 3)
+	p.CubicCurveTo(4, 4, 5, 5, 6, 6)
+	p.Close()
+
+	got := p.String()
+	expect := "" +
+		"MoveTo: 0.000000, 0.000000\n" +
+		"LineTo: 1.000000, 1.000000\n" +
+		"QuadCurveTo: 2.000000, 2.000000, 3.000000, 3.000000\n" +
+		"CubicCurveTo: 4.000000, 4.000000, 5.000000, 5.000000, 6.000000, 6.000000\n" +
+		"Close\n"
+	assert.Equal(t, expect, got)
+}

--- a/chartdraw/drawing/stroker_test.go
+++ b/chartdraw/drawing/stroker_test.go
@@ -1,0 +1,20 @@
+package drawing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLineStrokerLine(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordFlattenerEnd{}
+	ls := NewLineStroker(rec)
+	ls.MoveTo(0, 0)
+	ls.LineTo(2, 0)
+	ls.End()
+
+	expect := []string{"M0.0,-0.5", "L2.0,-0.5", "L2.0,0.5", "L0.0,0.5", "L0.0,-0.5", "E"}
+	assert.Equal(t, expect, rec.moves)
+}

--- a/chartdraw/drawing/util_test.go
+++ b/chartdraw/drawing/util_test.go
@@ -1,0 +1,88 @@
+package drawing
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/golang/freetype/truetype"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/image/math/fixed"
+)
+
+func TestPointsToPixels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		dpi, points float64
+		want        float64
+	}{
+		{72, 72, 72},
+		{96, 72, 96},
+		{96, 36, 48},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got := PointsToPixels(tt.dpi, tt.points)
+			assert.InDelta(t, tt.want, got, 0.0001)
+		})
+	}
+}
+
+func TestDistanceFuncs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		x1, y1, x2, y2 float64
+		want           float64
+	}{
+		{0, 0, 3, 4, 5},
+		{1, 2, 1, 2, 0},
+		{-1, -1, -4, -5, 5},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.InDelta(t, tt.want, distance(tt.x1, tt.y1, tt.x2, tt.y2), 0.0001)
+		})
+	}
+}
+
+func TestVectorDistance(t *testing.T) {
+	t.Parallel()
+	tests := []struct{ dx, dy, want float64 }{
+		{3, 4, 5},
+		{0, 0, 0},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.InDelta(t, tt.want, vectorDistance(tt.dx, tt.dy), 0.0001)
+		})
+	}
+}
+
+func TestFUnitsConversion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   fixed.Int26_6
+		want float64
+	}{
+		{64, 1},
+		{96, 1.5},
+		{-64, -1},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.InDelta(t, tt.want, fUnitsToFloat64(tt.in), 0.0001)
+		})
+	}
+}
+
+func TestPointToF64Point(t *testing.T) {
+	t.Parallel()
+
+	p := truetype.Point{X: 128, Y: -64}
+	x, y := pointToF64Point(p)
+	assert.InDelta(t, 2.0, x, 0.0001)
+	// Y is negated inside function
+	assert.InDelta(t, 1.0, y, 0.0001)
+}


### PR DESCRIPTION
- add SubdivideCubic, TraceCubic and TraceArc tests
- add Bresenham and PolylineBresenham tests
- add dashed line and stroker geometry tests