### PR TITLE
Expand drawing package tests

### DIFF
--- a/chartdraw/drawing/demux_flattener_test.go
+++ b/chartdraw/drawing/demux_flattener_test.go
@@ -1,0 +1,46 @@
+package drawing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/image/math/fixed"
+)
+
+type recordAdder struct{ starts, adds []fixed.Point26_6 }
+
+func (r *recordAdder) Start(p fixed.Point26_6)      { r.starts = append(r.starts, p) }
+func (r *recordAdder) Add1(p fixed.Point26_6)       { r.adds = append(r.adds, p) }
+func (r *recordAdder) Add2(b, c fixed.Point26_6)    {}
+func (r *recordAdder) Add3(b, c, d fixed.Point26_6) {}
+
+func TestDemuxFlattener(t *testing.T) {
+	t.Parallel()
+
+	r1 := &recordFlattener{}
+	r2 := &recordFlattener{}
+	d := DemuxFlattener{Flatteners: []Flattener{r1, r2}}
+	d.MoveTo(1, 2)
+	d.LineTo(3, 4)
+	d.End()
+	assert.Equal(t, r1.moves, r2.moves)
+	assert.Equal(t, []string{"M1.0,2.0", "L3.0,4.0"}, r1.moves)
+}
+
+func TestFtLineBuilder(t *testing.T) {
+	t.Parallel()
+
+	ad := &recordAdder{}
+	ft := FtLineBuilder{Adder: ad}
+	ft.MoveTo(1, 1)
+	ft.LineTo(2, 3)
+	ft.End()
+	if assert.Len(t, ad.starts, 1) {
+		assert.Equal(t, fixed.Int26_6(64), ad.starts[0].X)
+		assert.Equal(t, fixed.Int26_6(64), ad.starts[0].Y)
+	}
+	if assert.Len(t, ad.adds, 1) {
+		assert.Equal(t, fixed.Int26_6(128), ad.adds[0].X)
+		assert.Equal(t, fixed.Int26_6(192), ad.adds[0].Y)
+	}
+}

--- a/chartdraw/drawing/painter_draw_test.go
+++ b/chartdraw/drawing/painter_draw_test.go
@@ -1,0 +1,32 @@
+package drawing
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/image/draw"
+)
+
+func TestDrawImageTransform(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	src.Set(0, 0, color.White)
+	dst := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	DrawImage(src, dst, NewTranslationMatrix(1, 1), draw.Over, LinearFilter)
+	_, _, _, a := dst.At(1, 1).RGBA()
+	assert.Equal(t, uint32(0xffff), a)
+}
+
+func TestDrawImageScale(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	src.Set(0, 0, color.White)
+	dst := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	DrawImage(src, dst, NewScaleMatrix(2, 2), draw.Over, LinearFilter)
+	_, _, _, a := dst.At(1, 1).RGBA()
+	assert.Equal(t, uint32(0xffff), a)
+}

--- a/chartdraw/drawing/raster_graphic_context_test.go
+++ b/chartdraw/drawing/raster_graphic_context_test.go
@@ -1,0 +1,97 @@
+package drawing
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRasterGraphicContextBasic(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	rgc := NewRasterGraphicContext(img)
+	assert.Equal(t, defaultDPI, rgc.GetDPI())
+	rgc.SetDPI(72)
+	assert.InDelta(t, 72.0, rgc.GetDPI(), 0.0001)
+}
+
+func TestRasterFillRectAndClear(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	rgc := NewRasterGraphicContext(img)
+	rgc.SetFillColor(color.RGBA{255, 0, 0, 255})
+	rgc.FillRect(0, 0, 2, 2)
+	_, _, _, a := img.At(1, 1).RGBA()
+	assert.Equal(t, uint32(0xffff), a)
+
+	rgc.Clear()
+	_, _, _, a = img.At(1, 1).RGBA()
+	assert.Equal(t, uint32(0xffff), a)
+}
+
+func TestRasterFillRectanglePath(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	rgc := NewRasterGraphicContext(img)
+	rgc.SetFillColor(color.RGBA{0, 255, 0, 255})
+	p := &Path{}
+	p.MoveTo(0, 0)
+	p.LineTo(2, 0)
+	p.LineTo(2, 2)
+	p.LineTo(0, 2)
+	p.LineTo(0, 0)
+	rgc.Fill(p)
+	_, _, _, a := img.At(1, 1).RGBA()
+	assert.Equal(t, uint32(0xffff), a)
+}
+
+func TestRasterDrawImage(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	src.Set(0, 0, color.White)
+	dst := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	rgc := NewRasterGraphicContext(dst)
+	rgc.DrawImage(src)
+	_, _, _, a := dst.At(0, 0).RGBA()
+	assert.Equal(t, uint32(0xffff), a)
+}
+
+func TestRasterStrokeAndFillStroke(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	rgc := NewRasterGraphicContext(img)
+	rgc.SetLineWidth(1)
+	rgc.SetStrokeColor(color.Black)
+	rgc.SetFillColor(color.RGBA{0, 0, 255, 255})
+
+	p := &Path{}
+	p.MoveTo(0, 0)
+	p.LineTo(2, 0)
+	p.LineTo(2, 2)
+	p.LineTo(0, 2)
+	p.Close()
+
+	rgc.FillStroke(p)
+	_, _, _, a := img.At(1, 1).RGBA()
+	assert.Equal(t, uint32(0xffff), a) // fill
+	_, _, _, a = img.At(0, 0).RGBA()
+	assert.Equal(t, uint32(0xffff), a) // stroke
+
+	img2 := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	rgc = NewRasterGraphicContext(img2)
+	rgc.SetLineWidth(1)
+	rgc.SetStrokeColor(color.Black)
+	p = &Path{}
+	p.MoveTo(0, 0)
+	p.LineTo(2, 0)
+	rgc.Stroke(p)
+	_, _, _, a = img2.At(1, 0).RGBA()
+	assert.Equal(t, uint32(0xffff), a)
+}

--- a/chartdraw/drawing/raster_graphic_context_test.go
+++ b/chartdraw/drawing/raster_graphic_context_test.go
@@ -13,9 +13,9 @@ func TestRasterGraphicContextBasic(t *testing.T) {
 
 	img := image.NewRGBA(image.Rect(0, 0, 3, 3))
 	rgc := NewRasterGraphicContext(img)
-	assert.Equal(t, defaultDPI, rgc.GetDPI())
+	assert.InDelta(t, defaultDPI, rgc.GetDPI(), 0.0)
 	rgc.SetDPI(72)
-	assert.InDelta(t, 72.0, rgc.GetDPI(), 0.0001)
+	assert.InDelta(t, 72.0, rgc.GetDPI(), 0.0)
 }
 
 func TestRasterFillRectAndClear(t *testing.T) {

--- a/chartdraw/drawing/stack_graphic_context_test.go
+++ b/chartdraw/drawing/stack_graphic_context_test.go
@@ -1,0 +1,62 @@
+package drawing
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStackGraphicContextSaveRestore(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	gc.SetLineWidth(2)
+	gc.MoveTo(1, 1)
+	gc.Save()
+	gc.SetLineWidth(4)
+	gc.LineTo(2, 2)
+	gc.Restore()
+	assert.InDelta(t, 2.0, gc.current.LineWidth, 0.0001)
+	x, y := gc.LastPoint()
+	assert.InDelta(t, 1.0, x, 0.0001)
+	assert.InDelta(t, 1.0, y, 0.0001)
+}
+
+func TestStackGraphicContextTransforms(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	gc.Translate(2, 3)
+	tr := gc.GetMatrixTransform()
+	x, y := tr.TransformPoint(0, 0)
+	assert.InDelta(t, 2.0, x, 0.0001)
+	assert.InDelta(t, 3.0, y, 0.0001)
+	gc.Rotate(math.Pi / 2)
+	tr = gc.GetMatrixTransform()
+	x, y = tr.TransformPoint(1, 0)
+	assert.InDelta(t, 2.0, x, 0.0001)
+	assert.InDelta(t, 4.0, y, 0.0001)
+}
+
+func TestStackGraphicContextColors(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	gc.SetStrokeColor(ColorRed)
+	gc.SetFillColor(ColorBlue)
+	assert.Equal(t, ColorRed, gc.current.StrokeColor)
+	assert.Equal(t, ColorBlue, gc.current.FillColor)
+}
+
+func TestStackMatrixTransform(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	tr := NewTranslationMatrix(5, 7)
+	gc.SetMatrixTransform(tr)
+	got := gc.GetMatrixTransform()
+	x, y := got.TransformPoint(0, 0)
+	assert.InDelta(t, 5.0, x, 0.0001)
+	assert.InDelta(t, 7.0, y, 0.0001)
+}

--- a/chartdraw/drawing/text_test.go
+++ b/chartdraw/drawing/text_test.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-analyze/charts/chartdraw/roboto"
 	"github.com/golang/freetype/truetype"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/image/math/fixed"
 )
 
 type recordBuilder struct{ ops []string }
@@ -41,4 +44,17 @@ func TestDrawContour(t *testing.T) {
 	}
 
 	assert.Equal(t, expect, rec.ops)
+}
+
+func TestFontExtents(t *testing.T) {
+	t.Parallel()
+
+	f, err := truetype.Parse(roboto.Roboto)
+	require.NoError(t, err)
+	ext := Extents(f, 10)
+	bounds := f.Bounds(fixed.Int26_6(f.FUnitsPerEm()))
+	scale := 10 / float64(f.FUnitsPerEm())
+	assert.InDelta(t, float64(bounds.Max.Y)*scale, ext.Ascent, 0.0001)
+	assert.InDelta(t, float64(bounds.Min.Y)*scale, ext.Descent, 0.0001)
+	assert.InDelta(t, float64(bounds.Max.Y-bounds.Min.Y)*scale, ext.Height, 0.0001)
 }


### PR DESCRIPTION
## Summary
- refine LastPoint and rectangle checks
- test raster context stroke operations
- ensure stack context matrix transforms work

Overall adds about 24% more test coverage to the `chartdraw/drawing` package.