### PR TITLE
refactor: Move internal splitSlice and filterSlice to bulk module

### DIFF
--- a/echarts.go
+++ b/echarts.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/go-analyze/bulk"
 )
 
 func convertToArray(data []byte) []byte {
@@ -270,7 +272,7 @@ type EChartsMarkPoint struct {
 func (emp *EChartsMarkPoint) ToSeriesMarkPoint() SeriesMarkPoint {
 	return SeriesMarkPoint{
 		SymbolSize: emp.SymbolSize,
-		Points: sliceConversion(emp.Data, func(i EChartsMarkData) SeriesMark {
+		Points: bulk.SliceTransform(emp.Data, func(i EChartsMarkData) SeriesMark {
 			return SeriesMark{Type: i.Type}
 		}),
 	}
@@ -284,7 +286,7 @@ type EChartsMarkLine struct {
 // ToSeriesMarkLine converts the mark line to the internal representation.
 func (eml *EChartsMarkLine) ToSeriesMarkLine() SeriesMarkLine {
 	return SeriesMarkLine{
-		Lines: sliceConversion(eml.Data, func(i EChartsMarkData) SeriesMark {
+		Lines: bulk.SliceTransform(eml.Data, func(i EChartsMarkData) SeriesMark {
 			return SeriesMark{Type: i.Type}
 		}),
 	}
@@ -347,7 +349,7 @@ func (esList EChartsSeriesList) ToSeriesList() GenericSeriesList {
 		}
 		seriesList = append(seriesList, GenericSeries{
 			Type: item.Type,
-			Values: sliceConversion(item.Data, func(dataItem EChartsSeriesData) float64 {
+			Values: bulk.SliceTransform(item.Data, func(dataItem EChartsSeriesData) float64 {
 				return dataItem.Value.First()
 			}),
 			YAxisIndex: item.YAxisIndex,
@@ -544,7 +546,7 @@ func (eo *EChartsOption) ToOption() ChartOption {
 		}
 	}
 	o.YAxis = yAxisOptions
-	o.Children = sliceConversion(eo.Children, func(child EChartsOption) ChartOption {
+	o.Children = bulk.SliceTransform(eo.Children, func(child EChartsOption) ChartOption {
 		return child.ToOption()
 	})
 	return o

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/dustin/go-humanize v1.0.1
+	github.com/go-analyze/bulk v0.0.3
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/image v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/go-analyze/bulk v0.0.3 h1:4u3EuGeMsLHwfyrfPRB6Fsar0O1KOzUR68Y+F0Qy0yY=
+github.com/go-analyze/bulk v0.0.3/go.mod h1:COn1t9AN7JJukKJSJ4YAx1fjTGZET9nbnogIIDxR3lk=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/series.go
+++ b/series.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"sort"
 
+	"github.com/go-analyze/bulk"
+
 	"github.com/go-analyze/charts/chartdraw"
 )
 
@@ -72,13 +74,13 @@ func appendMarks(m SeriesMarkList, global bool, markTypes []string) SeriesMarkLi
 type SeriesMarkList []SeriesMark
 
 func (m SeriesMarkList) splitGlobal() (SeriesMarkList, SeriesMarkList) {
-	return sliceSplit(m, func(v SeriesMark) bool {
+	return bulk.SliceSplit(m, func(v SeriesMark) bool {
 		return !v.Global
 	})
 }
 
 func (m SeriesMarkList) filterGlobal(global bool) SeriesMarkList {
-	return sliceFilter(m, func(v SeriesMark) bool {
+	return bulk.SliceFilter(m, func(v SeriesMark) bool {
 		return v.Global == global
 	})
 }

--- a/util.go
+++ b/util.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+	"github.com/go-analyze/bulk"
 
 	"github.com/go-analyze/charts/chartdraw"
 )
@@ -82,109 +83,12 @@ func reverseSlice[T any](s []T) {
 
 // SliceToFloat64 converts a slice of arbitrary types to float64 to be used as chart values.
 func SliceToFloat64[T any](slice []T, conversion func(T) float64) []float64 {
-	return sliceConversion(slice, conversion)
+	return bulk.SliceTransform(slice, conversion)
 }
 
 // IntSliceToFloat64 converts an int slice to a float64 slice so that it can be used for chart values.
 func IntSliceToFloat64(slice []int) []float64 {
-	return sliceConversion(slice, func(i int) float64 { return float64(i) })
-}
-
-func sliceConversion[I any, R any](input []I, conversion func(I) R) []R {
-	result := make([]R, len(input))
-	for i, v := range input {
-		result[i] = conversion(v)
-	}
-	return result
-}
-
-// sliceSplit will split a slice in half based on a conditional function passed in. The right result are true values,
-// second result being values that tested false.
-func sliceSplit[T any](slice []T, test func(v T) bool) ([]T, []T) {
-	if len(slice) == 0 {
-		return nil, nil
-	}
-
-	var splitIndex int
-	first := test(slice[0])
-	for splitIndex = 1; splitIndex < len(slice); splitIndex++ {
-		if first != test(slice[splitIndex]) {
-			break
-		}
-	}
-
-	// If all are the same, return early
-	if splitIndex == len(slice) {
-		if first {
-			return slice, nil
-		} else {
-			return nil, slice
-		}
-	}
-
-	// Allocate slices and copy first segment
-	remainingBuff := len(slice) - splitIndex
-	if remainingBuff > 2048 {
-		remainingBuff /= 2
-	}
-	var trueList, falseList []T
-	if first {
-		trueList = append(make([]T, 0, splitIndex+remainingBuff-1), slice[:splitIndex]...)
-		falseList = append(make([]T, 0, remainingBuff), slice[splitIndex])
-	} else {
-		falseList = append(make([]T, 0, splitIndex+remainingBuff-1), slice[:splitIndex]...)
-		trueList = append(make([]T, 0, remainingBuff), slice[splitIndex])
-	}
-	// Finish iterating appending remaining elements
-	for i := splitIndex + 1; i < len(slice); i++ {
-		if test(slice[i]) {
-			trueList = append(trueList, slice[i])
-		} else {
-			falseList = append(falseList, slice[i])
-		}
-	}
-
-	return trueList, falseList
-}
-
-// sliceFilter iterates over the slice, testing each element with the provided function. The returned slice are items
-// which had a true result.
-func sliceFilter[T any](slice []T, test func(v T) bool) []T {
-	for falseIndex, v := range slice {
-		if !test(v) {
-			if falseIndex == 0 {
-				// iterate until a true result is found, then start appending at that point
-				var result []T
-				for i := falseIndex + 1; i < len(slice); i++ {
-					if test(slice[i]) {
-						if result == nil {
-							remainingBuff := len(slice) - i
-							if remainingBuff > 2048 {
-								remainingBuff /= 2
-							}
-							result = make([]T, 0, remainingBuff)
-						}
-						result = append(result, slice[i])
-					}
-				}
-				return result
-			} else {
-				// copy all records that already passed, and then finish iteration to produce result
-				remainingBuff := len(slice) - falseIndex - 1
-				if remainingBuff > 2048 {
-					remainingBuff /= 2
-				}
-				result := append(make([]T, 0, falseIndex+remainingBuff), slice[:falseIndex]...)
-				for i := falseIndex + 1; i < len(slice); i++ {
-					if test(slice[i]) {
-						result = append(result, slice[i])
-					}
-				}
-				return result
-			}
-		}
-	}
-	return slice // all records tested to true
+	return bulk.SliceTransform(slice, func(i int) float64 { return float64(i) })
 }
 
 func sliceMaxLen[T any](values ...[]T) int {

--- a/util_test.go
+++ b/util_test.go
@@ -130,6 +130,7 @@ func TestSliceToFloat64(t *testing.T) {
 		result := SliceToFloat64(input, func(i int) float64 { return float64(i) })
 		assert.Equal(t, expected, result)
 	})
+
 	t.Run("string", func(t *testing.T) {
 		input := []string{"1.5", "2.5", "3.5"}
 		expected := []float64{1.5, 2.5, 3.5}
@@ -141,12 +142,14 @@ func TestSliceToFloat64(t *testing.T) {
 		})
 		assert.Equal(t, expected, result)
 	})
+
 	t.Run("empty", func(t *testing.T) {
 		input := []string{}
 		expected := []float64{}
 		result := SliceToFloat64(input, func(s string) float64 { return 0 })
 		assert.Equal(t, expected, result)
 	})
+
 	t.Run("nil", func(t *testing.T) {
 		var input []int
 		expected := []float64{}
@@ -188,126 +191,6 @@ func TestIntSliceToFloat64(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i)+"-"+tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, IntSliceToFloat64(tt.input))
-		})
-	}
-}
-
-var sliceSplitTestCases = []struct {
-	name        string
-	input       []int
-	testFunc    func(v int) bool
-	expectTrue  []int
-	expectFalse []int
-}{
-	{
-		name:        "all_true",
-		input:       []int{2, 4, 6},
-		testFunc:    func(v int) bool { return v%2 == 0 },
-		expectTrue:  []int{2, 4, 6},
-		expectFalse: nil,
-	},
-	{
-		name:        "all_false",
-		input:       []int{1, 3, 5},
-		testFunc:    func(v int) bool { return v%2 == 0 },
-		expectTrue:  nil,
-		expectFalse: []int{1, 3, 5},
-	},
-	{
-		name:        "single_true",
-		input:       []int{2},
-		testFunc:    func(v int) bool { return v%2 == 0 },
-		expectTrue:  []int{2},
-		expectFalse: nil,
-	},
-	{
-		name:        "single_false",
-		input:       []int{1},
-		testFunc:    func(v int) bool { return v%2 == 0 },
-		expectTrue:  nil,
-		expectFalse: []int{1},
-	},
-	{
-		name:        "one_true",
-		input:       []int{1, 2, 3, 4, 6, 8},
-		testFunc:    func(v int) bool { return v == 1 },
-		expectTrue:  []int{1},
-		expectFalse: []int{2, 3, 4, 6, 8},
-	},
-	{
-		name:        "true_end",
-		input:       []int{2, 3, 4, 6, 8, 1, 1},
-		testFunc:    func(v int) bool { return v == 1 },
-		expectTrue:  []int{1, 1},
-		expectFalse: []int{2, 3, 4, 6, 8},
-	},
-	{
-		name:        "mixed_split_first",
-		input:       []int{1, 2, 1, 4, 6, 8},
-		testFunc:    func(v int) bool { return v%2 == 0 },
-		expectTrue:  []int{2, 4, 6, 8},
-		expectFalse: []int{1, 1},
-	},
-	{
-		name:        "mixed_split_second",
-		input:       []int{2, 1, 4, 6, 8},
-		testFunc:    func(v int) bool { return v%2 == 0 },
-		expectTrue:  []int{2, 4, 6, 8},
-		expectFalse: []int{1},
-	},
-	{
-		name:        "mixed_split_middle",
-		input:       []int{2, 4, 6, 1, 3, 5, 8},
-		testFunc:    func(v int) bool { return v%2 == 0 },
-		expectTrue:  []int{2, 4, 6, 8},
-		expectFalse: []int{1, 3, 5},
-	},
-	{
-		name:        "mixed_split_last",
-		input:       []int{2, 4, 6, 1},
-		testFunc:    func(v int) bool { return v%2 == 0 },
-		expectTrue:  []int{2, 4, 6},
-		expectFalse: []int{1},
-	},
-	{
-		name:        "empty",
-		input:       []int{},
-		testFunc:    func(v int) bool { return v > 0 },
-		expectTrue:  nil,
-		expectFalse: nil,
-	},
-	{
-		name:        "nil",
-		input:       nil,
-		testFunc:    func(v int) bool { return v > 0 },
-		expectTrue:  nil,
-		expectFalse: nil,
-	},
-}
-
-func TestSliceSplit(t *testing.T) {
-	t.Parallel()
-
-	for i, tt := range sliceSplitTestCases {
-		t.Run(strconv.Itoa(i)+"-"+tt.name, func(t *testing.T) {
-			trueSlice, falseSlice := sliceSplit(tt.input, tt.testFunc)
-			assert.Equal(t, tt.expectTrue, trueSlice)
-			assert.Equal(t, tt.expectFalse, falseSlice)
-		})
-	}
-}
-
-func TestSliceFilter(t *testing.T) {
-	t.Parallel()
-
-	for i, tt := range sliceSplitTestCases {
-		t.Run(strconv.Itoa(i)+"-"+tt.name, func(t *testing.T) {
-			slice := sliceFilter(tt.input, tt.testFunc)
-			if len(tt.expectTrue) == 0 {
-				assert.Empty(t, slice)
-			} else {
-				assert.Equal(t, tt.expectTrue, slice)
-			}
 		})
 	}
 }
@@ -410,28 +293,6 @@ func TestAutoDivideSpans(t *testing.T) {
 	}
 }
 
-func TestSliceConversion(t *testing.T) {
-	t.Parallel()
-
-	t.Run("int_to_string", func(t *testing.T) {
-		input := []int{1, 2, 3}
-		result := sliceConversion(input, func(i int) string { return strconv.Itoa(i) })
-		assert.Equal(t, []string{"1", "2", "3"}, result)
-	})
-
-	t.Run("float_to_int", func(t *testing.T) {
-		input := []float64{1.1, 2.2}
-		result := sliceConversion(input, func(f float64) int { return int(f) })
-		assert.Equal(t, []int{1, 2}, result)
-	})
-
-	t.Run("empty", func(t *testing.T) {
-		var input []int
-		result := sliceConversion(input, func(i int) int { return i })
-		assert.Empty(t, result)
-	})
-}
-
 func TestSliceMaxLen(t *testing.T) {
 	t.Parallel()
 
@@ -476,20 +337,4 @@ func TestPolygonHelpers(t *testing.T) {
 	points := getPolygonPoints(center, 1, 4)
 	expectedPoints := []Point{{X: 0, Y: -1}, {X: 1, Y: 0}, {X: 0, Y: 1}, {X: -1, Y: 0}}
 	assert.Equal(t, expectedPoints, points)
-}
-
-func BenchmarkSliceSplit(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, tc := range sliceSplitTestCases {
-			_, _ = sliceSplit(tc.input, tc.testFunc)
-		}
-	}
-}
-
-func BenchmarkSliceFilter(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, tc := range sliceSplitTestCases {
-			_ = sliceFilter(tc.input, tc.testFunc)
-		}
-	}
 }


### PR DESCRIPTION
Internal to `charts` was the start of an optimized [slice split](https://github.com/go-analyze/charts/blob/f277f7332a4e7a96c53d1b5575e955d113f7d98e/util.go#L101-L148) and [slice filter](https://github.com/go-analyze/charts/blob/f277f7332a4e7a96c53d1b5575e955d113f7d98e/util.go#L150-L188) implementation.

I was able to come back to these slice operations and produce a more complete and robust set of slice tools in [go-analyze/bulk](https://github.com/go-analyze/bulk). With the transition to `bulk` the implementation has been made more robust. A more complete set of benchmarks, unit tests, and additional optimizations are all included as part of this change.

Not currently utilized by `charts`, additionally `bulk` offers "InPlace" operations for zero allocation for when copy safety is not necessary,