### PR TITLE
feat: Allow individual series label customization

### DIFF
--- a/alias_test.go
+++ b/alias_test.go
@@ -1,0 +1,324 @@
+package charts
+
+import (
+	"testing"
+
+	"github.com/golang/freetype/truetype"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-analyze/charts/chartdraw/matrix"
+)
+
+func TestFillFontStyleDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        FontStyle
+		defaultSize  float64
+		defaultColor Color
+		fontOptions  []*truetype.Font
+		expected     FontStyle
+	}{
+		{
+			name:         "empty_font_style_gets_all_defaults",
+			input:        FontStyle{},
+			defaultSize:  12,
+			defaultColor: ColorRed,
+			expected: FontStyle{
+				FontSize:  12,
+				FontColor: ColorRed,
+				Font:      getPreferredFont(),
+			},
+		},
+		{
+			name: "partial_font_style_keeps_existing_values",
+			input: FontStyle{
+				FontSize:  16,
+				FontColor: ColorBlue,
+			},
+			defaultSize:  12,
+			defaultColor: ColorRed,
+			expected: FontStyle{
+				FontSize:  16,        // keeps existing
+				FontColor: ColorBlue, // keeps existing
+				Font:      getPreferredFont(),
+			},
+		},
+		{
+			name: "zero_font_size_gets_default",
+			input: FontStyle{
+				FontSize:  0,
+				FontColor: ColorGreen,
+			},
+			defaultSize:  14,
+			defaultColor: ColorRed,
+			expected: FontStyle{
+				FontSize:  14,         // uses default
+				FontColor: ColorGreen, // keeps existing
+				Font:      getPreferredFont(),
+			},
+		},
+		{
+			name: "zero_color_gets_default",
+			input: FontStyle{
+				FontSize:  18,
+				FontColor: Color{}, // zero color
+			},
+			defaultSize:  12,
+			defaultColor: ColorYellow,
+			expected: FontStyle{
+				FontSize:  18,          // keeps existing
+				FontColor: ColorYellow, // uses default
+				Font:      getPreferredFont(),
+			},
+		},
+		{
+			name: "existing_font_is_preserved",
+			input: FontStyle{
+				Font: &truetype.Font{}, // some font
+			},
+			defaultSize:  12,
+			defaultColor: ColorRed,
+			expected: FontStyle{
+				FontSize:  12,
+				FontColor: ColorRed,
+				Font:      &truetype.Font{}, // keeps existing font
+			},
+		},
+		{
+			name: "all_values_set_no_defaults_applied",
+			input: FontStyle{
+				FontSize:  20,
+				FontColor: ColorPurple,
+				Font:      &truetype.Font{},
+			},
+			defaultSize:  12,
+			defaultColor: ColorRed,
+			expected: FontStyle{
+				FontSize:  20,               // keeps existing
+				FontColor: ColorPurple,      // keeps existing
+				Font:      &truetype.Font{}, // keeps existing
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fillFontStyleDefaults(tt.input, tt.defaultSize, tt.defaultColor, tt.fontOptions...)
+			assert.InDelta(t, tt.expected.FontSize, result.FontSize, matrix.DefaultEpsilon)
+			assert.Equal(t, tt.expected.FontColor, result.FontColor)
+			if tt.expected.Font != nil && result.Font != nil {
+				// Both have fonts, compare if they're the same instance
+				if tt.input.Font != nil {
+					// If input had a font, it should be preserved
+					assert.Equal(t, tt.input.Font, result.Font)
+				} else {
+					// If input had no font, should get default font
+					assert.NotNil(t, result.Font)
+				}
+			} else if tt.expected.Font == nil && result.Font == nil {
+				// Both should be nil
+			} else {
+				t.Errorf("Font mismatch: expected %v, got %v", tt.expected.Font, result.Font)
+			}
+		})
+	}
+}
+
+func TestMergeFontStyles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		primary  FontStyle
+		defaults []FontStyle
+		expected FontStyle
+	}{
+		{
+			name:    "empty_primary_uses_first_available_defaults",
+			primary: FontStyle{},
+			defaults: []FontStyle{
+				{FontSize: 12, FontColor: ColorRed, Font: &truetype.Font{}},
+			},
+			expected: FontStyle{
+				FontSize:  12,
+				FontColor: ColorRed,
+				Font:      &truetype.Font{},
+			},
+		},
+		{
+			name: "primary_values_take_precedence",
+			primary: FontStyle{
+				FontSize:  16,
+				FontColor: ColorBlue,
+			},
+			defaults: []FontStyle{
+				{FontSize: 12, FontColor: ColorRed, Font: &truetype.Font{}},
+			},
+			expected: FontStyle{
+				FontSize:  16,               // from primary
+				FontColor: ColorBlue,        // from primary
+				Font:      &truetype.Font{}, // from default
+			},
+		},
+		{
+			name:    "uses_first_available_value_from_multiple_defaults",
+			primary: FontStyle{},
+			defaults: []FontStyle{
+				{},                                    // empty first default
+				{FontSize: 14},                        // has size
+				{FontSize: 18, FontColor: ColorGreen}, // has size and color
+			},
+			expected: FontStyle{
+				FontSize:  14,         // from second default (first with size)
+				FontColor: ColorGreen, // from third default (first with color)
+				Font:      nil,        // no defaults have font
+			},
+		},
+		{
+			name: "partial_primary_fills_from_defaults",
+			primary: FontStyle{
+				FontSize: 20, // has size
+				// missing color and font
+			},
+			defaults: []FontStyle{
+				{FontColor: ColorPurple}, // has color
+				{Font: &truetype.Font{}}, // has font
+			},
+			expected: FontStyle{
+				FontSize:  20,               // from primary
+				FontColor: ColorPurple,      // from first default
+				Font:      &truetype.Font{}, // from second default
+			},
+		},
+		{
+			name: "zero_values_in_primary_use_defaults",
+			primary: FontStyle{
+				FontSize:  0,       // zero value
+				FontColor: Color{}, // zero color
+				Font:      nil,     // nil font
+			},
+			defaults: []FontStyle{
+				{FontSize: 15, FontColor: ColorYellow, Font: &truetype.Font{}},
+			},
+			expected: FontStyle{
+				FontSize:  15,
+				FontColor: ColorYellow,
+				Font:      &truetype.Font{},
+			},
+		},
+		{
+			name: "no_defaults_primary_unchanged",
+			primary: FontStyle{
+				FontSize:  24,
+				FontColor: ColorBlack,
+			},
+			defaults: []FontStyle{},
+			expected: FontStyle{
+				FontSize:  24,
+				FontColor: ColorBlack,
+				Font:      nil,
+			},
+		},
+		{
+			name: "complex_precedence_scenario",
+			primary: FontStyle{
+				FontColor: ColorRed, // only color set
+			},
+			defaults: []FontStyle{
+				{FontSize: 10},                         // first default has size
+				{},                                     // empty default
+				{FontSize: 12, Font: &truetype.Font{}}, // third has size and font
+				{FontSize: 14, FontColor: ColorBlue, Font: &truetype.Font{}}, // fourth has all
+			},
+			expected: FontStyle{
+				FontSize:  10,               // from first default with size
+				FontColor: ColorRed,         // from primary
+				Font:      &truetype.Font{}, // from third default with font
+			},
+		},
+		{
+			name: "all_defaults_empty_primary_unchanged",
+			primary: FontStyle{
+				FontSize:  18,
+				FontColor: ColorGreen,
+				Font:      &truetype.Font{},
+			},
+			defaults: []FontStyle{
+				{}, {}, {}, // all empty
+			},
+			expected: FontStyle{
+				FontSize:  18,
+				FontColor: ColorGreen,
+				Font:      &truetype.Font{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeFontStyles(tt.primary, tt.defaults...)
+			assert.InDelta(t, tt.expected.FontSize, result.FontSize, matrix.DefaultEpsilon)
+			assert.Equal(t, tt.expected.FontColor, result.FontColor)
+
+			// Handle font comparison carefully since they're pointers
+			if tt.expected.Font != nil && result.Font != nil {
+				// Both should be non-nil, check if they match expected source
+				if tt.primary.Font != nil {
+					assert.Equal(t, tt.primary.Font, result.Font, "should preserve primary font")
+				} else {
+					// Should come from defaults, just verify it's not nil
+					assert.NotNil(t, result.Font, "should get font from defaults")
+				}
+			} else if tt.expected.Font == nil {
+				assert.Nil(t, result.Font, "font should be nil")
+			}
+		})
+	}
+}
+
+func TestMergeFontStylesEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_font_handling", func(t *testing.T) {
+		primary := FontStyle{}
+		defaults := []FontStyle{
+			{Font: nil},              // explicit nil
+			{Font: &truetype.Font{}}, // has font
+		}
+
+		result := mergeFontStyles(primary, defaults...)
+		assert.NotNil(t, result.Font, "should get font from second default")
+	})
+
+	t.Run("zero_vs_non_zero_color", func(t *testing.T) {
+		primary := FontStyle{
+			FontColor: Color{R: 0, G: 0, B: 0, A: 0}, // transparent/zero
+		}
+		defaults := []FontStyle{
+			{FontColor: ColorRed},
+		}
+
+		result := mergeFontStyles(primary, defaults...)
+		assert.Equal(t, ColorRed, result.FontColor, "zero color should be replaced")
+	})
+
+	t.Run("partial_alpha_color", func(t *testing.T) {
+		partialColor := Color{R: 100, G: 100, B: 100, A: 0} // has RGB but no alpha
+		primary := FontStyle{
+			FontColor: partialColor,
+		}
+		defaults := []FontStyle{
+			{FontColor: ColorBlue},
+		}
+
+		result := mergeFontStyles(primary, defaults...)
+		// Should keep the primary color even with zero alpha since IsZero() checks all components
+		if partialColor.IsZero() {
+			assert.Equal(t, ColorBlue, result.FontColor)
+		} else {
+			assert.Equal(t, partialColor, result.FontColor)
+		}
+	})
+}

--- a/doughnut_chart.go
+++ b/doughnut_chart.go
@@ -177,7 +177,21 @@ func (d *doughnutChart) renderChart(result *defaultRenderResult) (Box, error) {
 			// finally, render the label text at its resolved position
 			fontStyle := fillFontStyleDefaults(mergeFontStyles(s.seriesLabel.FontStyle, opt.CenterValuesFontStyle),
 				defaultLabelFontSize, opt.Theme.GetLabelTextColor(), seriesPainter.font)
-			seriesPainter.Text(s.label, lp.box.Left, lp.box.Bottom, 0, fontStyle)
+
+			// Apply label style overrides if present
+			var backgroundColor Color
+			var cornerRadius int
+			var borderColor Color
+			var borderWidth float64
+			if s.labelStyle != nil {
+				fontStyle = mergeFontStyles(s.labelStyle.FontStyle, fontStyle)
+				backgroundColor = s.labelStyle.BackgroundColor
+				cornerRadius = s.labelStyle.CornerRadius
+				borderColor = s.labelStyle.BorderColor
+				borderWidth = s.labelStyle.BorderWidth
+			}
+
+			drawLabelWithBackground(seriesPainter, s.label, lp.box.Left, lp.box.Bottom, 0, fontStyle, backgroundColor, cornerRadius, borderColor, borderWidth)
 		}
 	} else if strings.EqualFold(opt.CenterValues, "sum") {
 		opt.CenterValuesFontStyle = fillFontStyleDefaults(opt.CenterValuesFontStyle,

--- a/doughnut_chart_test.go
+++ b/doughnut_chart_test.go
@@ -194,6 +194,59 @@ func TestDoughnutChart(t *testing.T) {
 			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 20 20\nL 580 20\nL 580 380\nL 20 380\nL 20 20\" style=\"stroke:none;fill:white\"/><path  d=\"M 300 200\nL 440 87\nA 180 180 26.62 0 1 476 162\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(250,200,88)\"/><path  d=\"M 300 200\nL 369 34\nA 180 180 28.90 0 1 440 87\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(145,204,117)\"/><path  d=\"M 300 200\nL 300 20\nA 180 180 22.39 0 1 369 34\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 300 200\nL 476 162\nA 180 180 25.56 0 1 475 242\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(238,102,102)\"/><path  d=\"M 300 200\nL 475 242\nA 180 180 23.60 0 1 444 308\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(115,192,222)\"/><path  d=\"M 300 200\nL 444 308\nA 180 180 44.13 0 1 328 378\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(59,162,114)\"/><path  d=\"M 300 200\nL 328 378\nA 180 180 90.37 0 1 122 226\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(252,132,82)\"/><path  d=\"M 300 200\nL 122 226\nA 180 180 25.74 0 1 128 147\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(154,96,180)\"/><path  d=\"M 300 200\nL 128 147\nA 180 180 46.84 0 1 221 38\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(234,124,204)\"/><path  d=\"M 300 200\nL 221 38\nA 180 180 25.87 0 1 300 20\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(123,142,198)\"/><circle cx=\"300\" cy=\"200\" r=\"108\" style=\"stroke:none;fill:white\"/><path  d=\"M 341 101\nL 342 106\" style=\"stroke-width:2;stroke:rgb(84,112,198);fill:none\"/><text x=\"260\" y=\"119\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Cyprus: 6.21%</text><path  d=\"M 359 111\nL 354 119\" style=\"stroke-width:2;stroke:rgb(145,204,117);fill:none\"/><text x=\"261\" y=\"132\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Denmark: 8.02%</text><path  d=\"M 393 147\nL 378 155\" style=\"stroke-width:2;stroke:rgb(250,200,88);fill:none\"/><text x=\"294\" y=\"162\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Estonia: 7.39%</text><path  d=\"M 407 193\nL 386 194\" style=\"stroke-width:2;stroke:rgb(238,102,102);fill:none\"/><text x=\"302\" y=\"201\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Finland: 7.09%</text><path  d=\"M 401 237\nL 378 229\" style=\"stroke-width:2;stroke:rgb(115,192,222);fill:none\"/><text x=\"297\" y=\"236\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">France: 6.55%</text><path  d=\"M 362 288\nL 352 274\" style=\"stroke-width:2;stroke:rgb(59,162,114);fill:none\"/><text x=\"251\" y=\"274\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Germany: 12.25%</text><path  d=\"M 224 276\nL 239 261\" style=\"stroke-width:2;stroke:rgb(252,132,82);fill:none\"/><text x=\"239\" y=\"261\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Greece: 25.1%</text><path  d=\"M 195 177\nL 214 181\" style=\"stroke-width:2;stroke:rgb(154,96,180);fill:none\"/><text x=\"214\" y=\"188\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Hungary: 7.14%</text><path  d=\"M 224 125\nL 232 133\" style=\"stroke-width:2;stroke:rgb(234,124,204);fill:none\"/><text x=\"232\" y=\"146\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Ireland: 13.01%</text><path  d=\"M 266 98\nL 266 98\" style=\"stroke-width:2;stroke:rgb(123,142,198);fill:none\"/><text x=\"266\" y=\"111\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Italy: 7.18%</text></svg>",
 			pngCRC: 0x8673bb08,
 		},
+		{
+			name: "styled_custom_labels",
+			makeOptions: func() DoughnutChartOption {
+				return DoughnutChartOption{
+					SeriesList: NewSeriesListDoughnut([]float64{
+						1048, 735, 580, 484, 300,
+					}, DoughnutSeriesOption{
+						Names: []string{"Analytics", "Marketing", "Sales", "Support", "Development"},
+						Label: SeriesLabel{
+							Show: Ptr(true),
+							LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+								switch index {
+								case 0: // analytics - data icon with blue background
+									return "📊 " + name, &LabelStyle{
+										FontStyle:       FontStyle{FontColor: ColorWhite, FontSize: 12},
+										BackgroundColor: ColorBlue,
+										CornerRadius:    4,
+									}
+								case 1: // marketing - no icon with red background
+									return name, &LabelStyle{
+										FontStyle:       FontStyle{FontColor: ColorWhite, FontSize: 12},
+										BackgroundColor: ColorRed,
+										CornerRadius:    6,
+									}
+								case 2: // sales - money icon with green background
+									return "💰 " + name, &LabelStyle{
+										FontStyle:       FontStyle{FontColor: ColorBlack, FontSize: 11},
+										BackgroundColor: ColorLime,
+										CornerRadius:    3,
+										BorderColor:     ColorRed,
+										BorderWidth:     2,
+									}
+								case 3: // support - help icon with orange color
+									return "❓ " + name, &LabelStyle{
+										FontStyle: FontStyle{FontColor: ColorOrange, FontSize: 13},
+									}
+								default: // development, no label
+									return "", nil
+								}
+							},
+						},
+					}),
+					Title: TitleOption{
+						Show: Ptr(false),
+					},
+					Legend: LegendOption{
+						Show: Ptr(false),
+					},
+				}
+			},
+			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 20 20\nL 580 20\nL 580 380\nL 20 380\nL 20 20\" style=\"stroke:none;fill:white\"/><path  d=\"M 300 200\nL 300 56\nA 144 144 119.89 0 1 425 272\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 424 128\nL 437 121\nM 437 121\nL 452 121\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 455 106\nL 535 106\nL 535 106\nA 4 4 90.00 0 1 539 110\nL 539 126\nL 539 126\nA 4 4 90.00 0 1 535 130\nL 455 130\nL 455 130\nA 4 4 90.00 0 1 451 126\nL 451 110\nL 451 110\nA 4 4 90.00 0 1 455 106\nZ\" style=\"stroke:none;fill:blue\"/><text x=\"455\" y=\"126\" style=\"stroke:none;fill:white;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">📊 Analytics</text><path  d=\"M 300 200\nL 425 272\nA 144 144 84.08 0 1 242 332\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(145,204,117)\"/><path  d=\"M 344 336\nL 349 351\nM 349 351\nL 364 351\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:none\"/><path  d=\"M 369 336\nL 435 336\nL 435 336\nA 6 6 90.00 0 1 441 342\nL 441 354\nL 441 354\nA 6 6 90.00 0 1 435 360\nL 369 360\nL 369 360\nA 6 6 90.00 0 1 363 354\nL 363 342\nL 363 342\nA 6 6 90.00 0 1 369 336\nZ\" style=\"stroke:none;fill:red\"/><text x=\"367\" y=\"356\" style=\"stroke:none;fill:white;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Marketing</text><path  d=\"M 300 200\nL 242 332\nA 144 144 66.35 0 1 156 199\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(250,200,88)\"/><path  d=\"M 180 278\nL 167 286\nM 167 286\nL 152 286\" style=\"stroke-width:1;stroke:rgb(250,200,88);fill:none\"/><path  d=\"M 103 272\nL 154 272\nL 154 272\nA 3 3 90.00 0 1 157 275\nL 157 292\nL 157 292\nA 3 3 90.00 0 1 154 295\nL 103 295\nL 103 295\nA 3 3 90.00 0 1 100 292\nL 100 275\nL 100 275\nA 3 3 90.00 0 1 103 272\nZ\" style=\"stroke-width:2;stroke:red;fill:lime\"/><text x=\"104\" y=\"291\" style=\"stroke:none;fill:black;font-size:14.1px;font-family:'Roboto Medium',sans-serif\">💰 Sales</text><path  d=\"M 300 200\nL 156 199\nA 144 144 55.37 0 1 219 81\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(238,102,102)\"/><path  d=\"M 173 133\nL 160 126\nM 160 126\nL 145 126\" style=\"stroke-width:1;stroke:rgb(238,102,102);fill:none\"/><text x=\"83\" y=\"131\" style=\"stroke:none;fill:rgb(255,165,0);font-size:16.6px;font-family:'Roboto Medium',sans-serif\">❓ Support</text><path  d=\"M 300 200\nL 219 81\nA 144 144 34.32 0 1 300 56\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(115,192,222)\"/><circle cx=\"300\" cy=\"200\" r=\"86\" style=\"stroke:none;fill:white\"/></svg>",
+			pngCRC: 0xc83980e4,
+		},
 	}
 
 	for i, tt := range tests {

--- a/examples/1-Painter/line_chart-10-gradient_labels/main.go
+++ b/examples/1-Painter/line_chart-10-gradient_labels/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/go-analyze/charts"
+)
+
+/*
+Example line chart demonstrating gradient label coloring.
+This shows how to:
+- Use LabelFormatterGradientGreenRed to color labels from green (min) to red (max)
+- Show labels with color-coding based on their values
+- Create visually appealing data presentations with automatic color scaling
+*/
+
+func writeFile(buf []byte) error {
+	tmpPath := "./tmp"
+	if err := os.MkdirAll(tmpPath, 0700); err != nil {
+		return err
+	}
+
+	file := filepath.Join(tmpPath, "line-chart-10-gradient-labels.png")
+	return os.WriteFile(file, buf, 0600)
+}
+
+func main() {
+	values := [][]float64{
+		{20, 15, 35, 40, 10, 55, 25, 45, 30, 50},
+	}
+
+	opt := charts.NewLineChartOptionWithData(values)
+	opt.XAxis.Labels = []string{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct"}
+	opt.SeriesList = charts.NewSeriesListLine(values, charts.LineSeriesOption{
+		Names: []string{"Sales Performance"},
+		Label: charts.SeriesLabel{
+			Show:           charts.Ptr(true),
+			LabelFormatter: charts.LabelFormatterGradientGreenRed(values[0]),
+		},
+	})
+	opt.Padding = charts.NewBoxEqual(20)
+	opt.Title = charts.TitleOption{
+		Text:    "Sales Performance with Gradient Label Colors",
+		Subtext: "(Green = Low Values, Red = High Values)",
+	}
+
+	p := charts.NewPainter(charts.PainterOptions{
+		OutputFormat: charts.ChartOutputPNG,
+		Width:        800,
+		Height:       500,
+	})
+
+	if err := p.LineChart(opt); err != nil {
+		panic(err)
+	} else if buf, err := p.Bytes(); err != nil {
+		panic(err)
+	} else if err = writeFile(buf); err != nil {
+		panic(err)
+	}
+}

--- a/examples/1-Painter/scatter_chart-4-top_n_labels/main.go
+++ b/examples/1-Painter/scatter_chart-4-top_n_labels/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/go-analyze/charts"
+)
+
+/*
+Example scatter chart demonstrating top-N label selection.
+This shows how to:
+- Use LabelFormatterTopN to show labels only for the highest N values
+- Reduce visual clutter by highlighting only the most important data points
+- Track website traffic over time with emphasis on peak traffic days
+*/
+
+func writeFile(buf []byte) error {
+	tmpPath := "./tmp"
+	if err := os.MkdirAll(tmpPath, 0700); err != nil {
+		return err
+	}
+
+	file := filepath.Join(tmpPath, "scatter-chart-4-top-n-labels.png")
+	return os.WriteFile(file, buf, 0600)
+}
+
+func main() {
+	// Sample data representing daily website visitors over 30 days (in thousands)
+	values := [][]float64{
+		{
+			15.2, 18.5, 22.1, 19.8, 25.4, 21.3, 17.9, 32.6, 28.1, 24.7,
+			31.5, 29.3, 26.8, 35.2, 41.7, 38.9, 33.1, 29.6, 27.4, 30.8,
+			36.3, 42.1, 39.5, 44.8, 48.3, 45.6, 40.2, 37.9, 34.5, 26.1,
+		},
+	}
+
+	opt := charts.NewScatterChartOptionWithData(values)
+	opt.XAxis.Labels = []string{"Day 1", "Day 2", "Day 3", "Day 4", "Day 5",
+		"Day 6", "Day 7", "Day 8", "Day 9", "Day 10",
+		"Day 11", "Day 12", "Day 13", "Day 14", "Day 15",
+		"Day 16", "Day 17", "Day 18", "Day 19", "Day 20",
+		"Day 21", "Day 22", "Day 23", "Day 24", "Day 25",
+		"Day 26", "Day 27", "Day 28", "Day 29", "Day 30"}
+	opt.YAxis[0].Min = charts.Ptr(0.0)
+	opt.YAxis[0].Max = charts.Ptr(50.0)
+	opt.SeriesList = charts.NewSeriesListScatter(values, charts.ScatterSeriesOption{
+		Names: []string{"Daily Visitors (k)"},
+		Label: charts.SeriesLabel{
+			Show: charts.Ptr(true),
+			// Show labels only for the top 5 traffic days
+			LabelFormatter: charts.LabelFormatterTopN(values[0], 5),
+			FontStyle: charts.FontStyle{
+				FontSize:  16,
+				FontColor: charts.ColorRedAlt1,
+			},
+		},
+	})
+	opt.Legend.Show = charts.Ptr(false)
+	opt.Padding = charts.NewBoxEqual(20)
+	opt.Title = charts.TitleOption{
+		Text:    "Website Traffic Over 30 Days - Peak Days Highlighted",
+		Subtext: "(Only top 5 traffic days show labels)",
+	}
+
+	p := charts.NewPainter(charts.PainterOptions{
+		OutputFormat: charts.ChartOutputPNG,
+		Width:        800,
+		Height:       500,
+	})
+
+	if err := p.ScatterChart(opt); err != nil {
+		panic(err)
+	} else if buf, err := p.Bytes(); err != nil {
+		panic(err)
+	} else if err = writeFile(buf); err != nil {
+		panic(err)
+	}
+}

--- a/examples/demo/themes/main.go
+++ b/examples/demo/themes/main.go
@@ -154,8 +154,10 @@ func renderMultiChart(themeName string) {
 		Theme: theme.WithBackgroundColor(charts.ColorTransparent),
 		SeriesList: charts.NewSeriesListPie(pieValues, charts.PieSeriesOption{
 			Label: charts.SeriesLabel{
-				Show:           charts.Ptr(true),
-				FormatTemplate: "{b} ({d})",
+				Show: charts.Ptr(true),
+				LabelFormatter: func(index int, name string, val float64) (string, *charts.LabelStyle) {
+					return name + "(" + charts.FormatValueHumanizeShort(val, 2, false) + ")", nil
+				},
 			},
 		}),
 		Radius:  "64",

--- a/funnel_chart_test.go
+++ b/funnel_chart_test.go
@@ -69,6 +69,102 @@ func TestFunnelChart(t *testing.T) {
 			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><path  d=\"M 552 304\nL 582 304\" style=\"stroke-width:3;stroke:rgb(84,112,198);fill:none\"/><circle cx=\"567\" cy=\"304\" r=\"5\" style=\"stroke-width:3;stroke:rgb(84,112,198);fill:rgb(84,112,198)\"/><text x=\"584\" y=\"310\" style=\"stroke:none;fill:rgb(70,70,70);font-size:5.1px;font-family:'Roboto Medium',sans-serif\">Show</text><path  d=\"M 552 324\nL 582 324\" style=\"stroke-width:3;stroke:rgb(145,204,117);fill:none\"/><circle cx=\"567\" cy=\"324\" r=\"5\" style=\"stroke-width:3;stroke:rgb(145,204,117);fill:rgb(145,204,117)\"/><text x=\"584\" y=\"330\" style=\"stroke:none;fill:rgb(70,70,70);font-size:5.1px;font-family:'Roboto Medium',sans-serif\">Click</text><path  d=\"M 552 344\nL 582 344\" style=\"stroke-width:3;stroke:rgb(250,200,88);fill:none\"/><circle cx=\"567\" cy=\"344\" r=\"5\" style=\"stroke-width:3;stroke:rgb(250,200,88);fill:rgb(250,200,88)\"/><text x=\"584\" y=\"350\" style=\"stroke:none;fill:rgb(70,70,70);font-size:5.1px;font-family:'Roboto Medium',sans-serif\">Visit</text><path  d=\"M 552 364\nL 582 364\" style=\"stroke-width:3;stroke:rgb(238,102,102);fill:none\"/><circle cx=\"567\" cy=\"364\" r=\"5\" style=\"stroke-width:3;stroke:rgb(238,102,102);fill:rgb(238,102,102)\"/><text x=\"584\" y=\"370\" style=\"stroke:none;fill:rgb(70,70,70);font-size:5.1px;font-family:'Roboto Medium',sans-serif\">Inquiry</text><path  d=\"M 552 384\nL 582 384\" style=\"stroke-width:3;stroke:rgb(115,192,222);fill:none\"/><circle cx=\"567\" cy=\"384\" r=\"5\" style=\"stroke-width:3;stroke:rgb(115,192,222);fill:rgb(115,192,222)\"/><text x=\"584\" y=\"390\" style=\"stroke:none;fill:rgb(70,70,70);font-size:5.1px;font-family:'Roboto Medium',sans-serif\">Order</text><path  d=\"M 0 0\nL 600 0\nL 540 78\nL 60 78\nL 0 0\" style=\"stroke:none;fill:rgb(84,112,198)\"/><text x=\"264\" y=\"39\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Show(100%)</text><path  d=\"M 60 80\nL 540 80\nL 480 158\nL 120 158\nL 60 80\" style=\"stroke:none;fill:rgb(145,204,117)\"/><text x=\"269\" y=\"119\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Click(80%)</text><path  d=\"M 120 160\nL 480 160\nL 420 238\nL 180 238\nL 120 160\" style=\"stroke:none;fill:rgb(250,200,88)\"/><text x=\"271\" y=\"199\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Visit(60%)</text><path  d=\"M 180 240\nL 420 240\nL 360 318\nL 240 318\nL 180 240\" style=\"stroke:none;fill:rgb(238,102,102)\"/><text x=\"264\" y=\"279\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Inquiry(40%)</text><path  d=\"M 240 320\nL 360 320\nL 300 398\nL 300 398\nL 240 320\" style=\"stroke:none;fill:rgb(115,192,222)\"/><text x=\"268\" y=\"359\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Order(20%)</text></svg>",
 			pngCRC: 0x332d7bde,
 		},
+		{
+			name: "with_label_formatter",
+			makeOptions: func() FunnelChartOption {
+				return FunnelChartOption{
+					SeriesList: NewSeriesListFunnel([]float64{
+						100, 80, 60, 40, 20,
+					}, FunnelSeriesOption{
+						Names: []string{"Show", "Click", "Visit", "Inquiry", "Order"},
+						Label: SeriesLabel{
+							Show: Ptr(true),
+							LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+								if index == 1 || index == 3 { // highlight 2nd and 4th items
+									return "⭐ " + name + ": " + strconv.FormatFloat(val, 'f', 0, 64), nil
+								}
+								return "", nil // hide other labels
+							},
+						},
+					}),
+					Legend: LegendOption{
+						Show: Ptr(false),
+					},
+				}
+			},
+			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><path  d=\"M 0 0\nL 600 0\nL 540 78\nL 60 78\nL 0 0\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 60 80\nL 540 80\nL 480 158\nL 120 158\nL 60 80\" style=\"stroke:none;fill:rgb(145,204,117)\"/><text x=\"269\" y=\"119\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">⭐ Click: 80</text><path  d=\"M 120 160\nL 480 160\nL 420 238\nL 180 238\nL 120 160\" style=\"stroke:none;fill:rgb(250,200,88)\"/><path  d=\"M 180 240\nL 420 240\nL 360 318\nL 240 318\nL 180 240\" style=\"stroke:none;fill:rgb(238,102,102)\"/><text x=\"263\" y=\"279\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">⭐ Inquiry: 40</text><path  d=\"M 240 320\nL 360 320\nL 300 398\nL 300 398\nL 240 320\" style=\"stroke:none;fill:rgb(115,192,222)\"/></svg>",
+			pngCRC: 0x886dac8,
+		},
+		{
+			name: "with_styled_labels",
+			makeOptions: func() FunnelChartOption {
+				return FunnelChartOption{
+					SeriesList: NewSeriesListFunnel([]float64{
+						100, 80, 60, 40, 20,
+					}, FunnelSeriesOption{
+						Names: []string{"Show", "Click", "Visit", "Inquiry", "Order"},
+						Label: SeriesLabel{
+							Show: Ptr(true),
+							LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+								switch index {
+								case 0: // first item - red background with rounded corners
+									return name, &LabelStyle{
+										FontStyle:       FontStyle{FontColor: ColorWhite, FontSize: 14},
+										BackgroundColor: ColorRed,
+										CornerRadius:    5,
+									}
+								case 1: // second item - blue background, larger font
+									return name, &LabelStyle{
+										FontStyle:       FontStyle{FontColor: ColorWhite, FontSize: 16},
+										BackgroundColor: ColorBlue,
+										CornerRadius:    3,
+										BorderColor:     ColorPurple,
+										BorderWidth:     2,
+									}
+								case 2: // third item - green background, square corners
+									return "🟢 " + name, &LabelStyle{
+										FontStyle:       FontStyle{FontColor: ColorBlack, FontSize: 12},
+										BackgroundColor: ColorLime,
+										BorderColor:     ColorRed,
+										BorderWidth:     2,
+									}
+								case 3: // fourth item - no background, custom color
+									return "⭐ " + name, &LabelStyle{
+										FontStyle: FontStyle{FontColor: ColorOrange, FontSize: 15},
+									}
+								default: // last item - no label
+									return "", nil
+								}
+							},
+						},
+					}),
+					Legend: LegendOption{
+						Show: Ptr(false),
+					},
+				}
+			},
+			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><path  d=\"M 0 0\nL 600 0\nL 540 78\nL 60 78\nL 0 0\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 279 17\nL 322 17\nL 322 17\nA 5 5 90.00 0 1 327 22\nL 327 38\nL 327 38\nA 5 5 90.00 0 1 322 43\nL 279 43\nL 279 43\nA 5 5 90.00 0 1 274 38\nL 274 22\nL 274 22\nA 5 5 90.00 0 1 279 17\nZ\" style=\"stroke:none;fill:red\"/><text x=\"278\" y=\"39\" style=\"stroke:none;fill:white;font-size:17.9px;font-family:'Roboto Medium',sans-serif\">Show</text><path  d=\"M 60 80\nL 540 80\nL 480 158\nL 120 158\nL 60 80\" style=\"stroke:none;fill:rgb(145,204,117)\"/><path  d=\"M 276 94\nL 324 94\nL 324 94\nA 3 3 90.00 0 1 327 97\nL 327 120\nL 327 120\nA 3 3 90.00 0 1 324 123\nL 276 123\nL 276 123\nA 3 3 90.00 0 1 273 120\nL 273 97\nL 273 97\nA 3 3 90.00 0 1 276 94\nZ\" style=\"stroke-width:2;stroke:purple;fill:blue\"/><text x=\"277\" y=\"119\" style=\"stroke:none;fill:white;font-size:20.4px;font-family:'Roboto Medium',sans-serif\">Click</text><path  d=\"M 120 160\nL 480 160\nL 420 238\nL 180 238\nL 120 160\" style=\"stroke:none;fill:rgb(250,200,88)\"/><path  d=\"M 273 179\nL 328 179\nL 328 203\nL 273 203\nL 273 179\" style=\"stroke-width:2;stroke:red;fill:lime\"/><text x=\"277\" y=\"199\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">🟢 Visit</text><path  d=\"M 180 240\nL 420 240\nL 360 318\nL 240 318\nL 180 240\" style=\"stroke:none;fill:rgb(238,102,102)\"/><text x=\"261\" y=\"279\" style=\"stroke:none;fill:rgb(255,165,0);font-size:19.2px;font-family:'Roboto Medium',sans-serif\">⭐ Inquiry</text><path  d=\"M 240 320\nL 360 320\nL 300 398\nL 300 398\nL 240 320\" style=\"stroke:none;fill:rgb(115,192,222)\"/></svg>",
+			pngCRC: 0x7c598da9,
+		},
+		{
+			name: "border_without_background",
+			makeOptions: func() FunnelChartOption {
+				values := []float64{100, 50}
+				opt := NewFunnelChartOptionWithData(values)
+				opt.SeriesList[0].Label = SeriesLabel{
+					Show: Ptr(true),
+					LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+						return "test label", &LabelStyle{
+							BorderColor: ColorRed,
+							BorderWidth: 2.5,
+						}
+					},
+				}
+				return opt
+			},
+			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><path  d=\"M 20 20\nL 580 20\nL 440 199\nL 160 199\nL 20 20\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 270 92\nL 331 92\nL 331 113\nL 270 113\nL 270 92\" style=\"stroke-width:2.5;stroke:red;fill:none\"/><text x=\"274\" y=\"109\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">test label</text><path  d=\"M 160 201\nL 440 201\nL 300 380\nL 300 380\nL 160 201\" style=\"stroke:none;fill:rgb(145,204,117)\"/><text x=\"284\" y=\"290\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">(50%)</text></svg>",
+			pngCRC: 0xdb0ac2e9,
+		},
 	}
 
 	for i, tt := range tests {

--- a/heat_map.go
+++ b/heat_map.go
@@ -26,9 +26,9 @@ type HeatMapOption struct {
 	// Values provides the 2D data for the heat map.
 	// The outer slice represents the rows (y-axis) and the inner slice represents the columns (x-axis).
 	Values [][]float64
-	// XAxis contains configuration options for the X-axis.
+	// XAxis contains configuration options for the x-axis.
 	XAxis HeatMapAxis
-	// YAxis contains configuration options for the Y-axis.
+	// YAxis contains configuration options for the y-axis.
 	YAxis HeatMapAxis
 	// ScaleMinValue overrides the minimum value for color gradient calculation. If nil, calculated from the data.
 	ScaleMinValue *float64
@@ -209,7 +209,7 @@ func (h *heatMap) Render() (Box, error) {
 	numRows := len(opt.Values)
 	numCols := sliceMaxLen(opt.Values...)
 
-	// Ensure X-axis labels cover all columns.
+	// Ensure x-axis labels cover all columns.
 	for len(opt.XAxis.Labels) < numCols {
 		opt.XAxis.Labels = append(opt.XAxis.Labels, strconv.Itoa(len(opt.XAxis.Labels)))
 	}

--- a/horizontal_bar_chart_test.go
+++ b/horizontal_bar_chart_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -121,6 +122,9 @@ func TestHorizontalBarChart(t *testing.T) {
 				series := opt.SeriesList
 				for i := range series {
 					series[i].Label.Show = Ptr(true)
+					series[i].Label.ValueFormatter = func(f float64) string {
+						return humanize.FtoaWithDigits(f, 2)
+					}
 				}
 				return opt
 			},

--- a/line_chart.go
+++ b/line_chart.go
@@ -186,11 +186,10 @@ func (l *lineChart) renderChart(result *defaultRenderResult) (Box, error) {
 
 			if labelPainter != nil {
 				labelPainter.Add(labelValue{
-					index:     index,
-					value:     item,
-					x:         points[i].X,
-					y:         points[i].Y,
-					fontStyle: series.Label.FontStyle,
+					index: index,
+					value: item,
+					x:     points[i].X,
+					y:     points[i].Y,
 				})
 			}
 		}

--- a/mark_point.go
+++ b/mark_point.go
@@ -73,7 +73,7 @@ func (m *markPointPainter) Render() (Box, error) {
 			if opt.seriesLabelPainter != nil {
 				// the series label has been replaced by our MarkPoint
 				// This is why MarkPoints must be rendered BEFORE series labels
-				opt.seriesLabelPainter.values[index].Text = ""
+				opt.seriesLabelPainter.values[index].text = ""
 			}
 
 			painter.Pin(p.X, p.Y-opt.symbolSize>>1, opt.symbolSize, opt.fillColor, opt.fillColor, 0.0)

--- a/pie_chart_test.go
+++ b/pie_chart_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -92,6 +93,9 @@ func TestPieChart(t *testing.T) {
 						Label: SeriesLabel{
 							Show:           Ptr(true),
 							FormatTemplate: "{b} ({c} ≅ {d})",
+							ValueFormatter: func(f float64) string {
+								return humanize.FtoaWithDigits(f, 2)
+							},
 						},
 					}),
 					Radius:  "200",
@@ -150,6 +154,9 @@ func TestPieChart(t *testing.T) {
 						Label: SeriesLabel{
 							Show:           Ptr(true),
 							FormatTemplate: "{b} ({c} ≅ {d})",
+							ValueFormatter: func(f float64) string {
+								return humanize.FtoaWithDigits(f, 2)
+							},
 						},
 					}),
 					Radius:  "200",
@@ -233,6 +240,9 @@ func TestPieChart(t *testing.T) {
 						Label: SeriesLabel{
 							Show:           Ptr(true),
 							FormatTemplate: "{b} ({c} ≅ {d})",
+							ValueFormatter: func(f float64) string {
+								return humanize.FtoaWithDigits(f, 2)
+							},
 						},
 					}),
 					Radius: "150",
@@ -255,6 +265,49 @@ func TestPieChart(t *testing.T) {
 			},
 			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 1150 550\"><path  d=\"M 20 20\nL 1130 20\nL 1130 530\nL 20 530\nL 20 20\" style=\"stroke:none;fill:white\"/><text x=\"981\" y=\"56\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">Fix label K (72586)</text><path  d=\"M 575 290\nL 717 241\nA 150 150 18.17 0 1 725 288\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(250,200,88)\"/><path  d=\"M 722 265\nL 737 262\nM 737 262\nL 752 262\" style=\"stroke-width:1;stroke:rgb(250,200,88);fill:none\"/><text x=\"755\" y=\"267\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">C (149086 ≅ 5.04%)</text><path  d=\"M 575 290\nL 687 191\nA 150 150 22.62 0 1 717 241\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(145,204,117)\"/><path  d=\"M 704 215\nL 717 207\nM 717 207\nL 732 207\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:none\"/><text x=\"735\" y=\"212\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">B (185596 ≅ 6.28%)</text><path  d=\"M 575 290\nL 575 140\nA 150 150 48.45 0 1 687 191\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 636 154\nL 642 140\nM 642 140\nL 657 140\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:none\"/><text x=\"660\" y=\"145\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">A (397594 ≅ 13.45%)</text><path  d=\"M 575 290\nL 725 288\nA 150 150 17.58 0 1 719 333\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(238,102,102)\"/><path  d=\"M 723 310\nL 738 313\nM 738 313\nL 753 313\" style=\"stroke-width:1;stroke:rgb(238,102,102);fill:none\"/><text x=\"756\" y=\"318\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">D (144258 ≅ 4.88%)</text><path  d=\"M 575 290\nL 719 333\nA 150 150 14.65 0 1 703 368\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(115,192,222)\"/><path  d=\"M 711 351\nL 725 357\nM 725 357\nL 740 357\" style=\"stroke-width:1;stroke:rgb(115,192,222);fill:none\"/><text x=\"743\" y=\"362\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">E (120194 ≅ 4.06%)</text><path  d=\"M 575 290\nL 703 368\nA 150 150 14.32 0 1 680 398\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(59,162,114)\"/><path  d=\"M 692 383\nL 703 393\nM 703 393\nL 718 393\" style=\"stroke-width:1;stroke:rgb(59,162,114);fill:none\"/><text x=\"721\" y=\"398\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">F (117514 ≅ 3.97%)</text><path  d=\"M 575 290\nL 680 398\nA 150 150 12.12 0 1 655 417\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(252,132,82)\"/><path  d=\"M 667 407\nL 676 419\nM 676 419\nL 691 419\" style=\"stroke-width:1;stroke:rgb(252,132,82);fill:none\"/><text x=\"694\" y=\"424\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">G (99412 ≅ 3.36%)</text><path  d=\"M 575 290\nL 655 417\nA 150 150 11.11 0 1 629 430\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(154,96,180)\"/><path  d=\"M 642 424\nL 648 437\nM 648 437\nL 663 437\" style=\"stroke-width:1;stroke:rgb(154,96,180);fill:none\"/><text x=\"666\" y=\"442\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">H (91135 ≅ 3.08%)</text><path  d=\"M 575 290\nL 629 430\nA 150 150 10.64 0 1 602 438\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(234,124,204)\"/><path  d=\"M 615 434\nL 619 453\nM 619 453\nL 634 453\" style=\"stroke-width:1;stroke:rgb(234,124,204);fill:none\"/><text x=\"637\" y=\"458\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">I (87282 ≅ 2.95%)</text><path  d=\"M 575 290\nL 602 438\nA 150 150 9.36 0 1 578 440\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(123,142,198)\"/><path  d=\"M 589 439\nL 591 469\nM 591 469\nL 606 469\" style=\"stroke-width:1;stroke:rgb(123,142,198);fill:none\"/><text x=\"609\" y=\"474\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">J (76790 ≅ 2.59%)</text><path  d=\"M 575 290\nL 425 300\nA 150 150 3.61 0 1 425 291\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(183,166,190)\"/><path  d=\"M 426 295\nL 411 295\nM 411 295\nL 396 295\" style=\"stroke-width:1;stroke:rgb(183,166,190);fill:none\"/><text x=\"308\" y=\"300\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Z (29608 ≅ 1%)</text><path  d=\"M 575 290\nL 426 310\nA 150 150 3.97 0 1 425 300\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(243,192,171)\"/><path  d=\"M 426 305\nL 411 311\nM 411 311\nL 396 311\" style=\"stroke-width:1;stroke:rgb(243,192,171);fill:none\"/><text x=\"297\" y=\"316\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Y (32566 ≅ 1.1%)</text><path  d=\"M 575 290\nL 428 321\nA 150 150 4.00 0 1 426 310\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(123,178,153)\"/><path  d=\"M 428 315\nL 413 327\nM 413 327\nL 398 327\" style=\"stroke-width:1;stroke:rgb(123,178,153);fill:none\"/><text x=\"299\" y=\"332\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">X (32788 ≅ 1.1%)</text><path  d=\"M 575 290\nL 431 331\nA 150 150 4.12 0 1 428 321\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(190,217,228)\"/><path  d=\"M 430 325\nL 415 343\nM 415 343\nL 400 343\" style=\"stroke-width:1;stroke:rgb(190,217,228);fill:none\"/><text x=\"290\" y=\"348\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">W (33784 ≅ 1.14%)</text><path  d=\"M 575 290\nL 434 342\nA 150 150 4.47 0 1 431 331\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(237,184,184)\"/><path  d=\"M 433 336\nL 419 359\nM 419 359\nL 404 359\" style=\"stroke-width:1;stroke:rgb(237,184,184);fill:none\"/><text x=\"297\" y=\"364\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">V (36644 ≅ 1.24%)</text><path  d=\"M 575 290\nL 439 353\nA 150 150 4.56 0 1 434 342\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(243,222,176)\"/><path  d=\"M 437 347\nL 423 375\nM 423 375\nL 408 375\" style=\"stroke-width:1;stroke:rgb(243,222,176);fill:none\"/><text x=\"301\" y=\"380\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">U (37414 ≅ 1.26%)</text><path  d=\"M 575 290\nL 445 364\nA 150 150 4.81 0 1 439 353\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(196,215,187)\"/><path  d=\"M 442 358\nL 429 391\nM 429 391\nL 414 391\" style=\"stroke-width:1;stroke:rgb(196,215,187);fill:none\"/><text x=\"308\" y=\"396\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">T (39476 ≅ 1.33%)</text><path  d=\"M 575 290\nL 452 376\nA 150 150 5.03 0 1 445 364\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(159,170,203)\"/><path  d=\"M 449 370\nL 436 407\nM 436 407\nL 421 407\" style=\"stroke-width:1;stroke:rgb(159,170,203);fill:none\"/><text x=\"315\" y=\"412\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">S (41242 ≅ 1.39%)</text><path  d=\"M 575 290\nL 462 388\nA 150 150 6.27 0 1 452 376\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(234,164,215)\"/><path  d=\"M 457 382\nL 445 423\nM 445 423\nL 430 423\" style=\"stroke-width:1;stroke:rgb(234,164,215);fill:none\"/><text x=\"323\" y=\"428\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">R (51460 ≅ 1.74%)</text><path  d=\"M 575 290\nL 474 401\nA 150 150 6.55 0 1 462 388\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(167,133,183)\"/><path  d=\"M 468 394\nL 457 439\nM 457 439\nL 442 439\" style=\"stroke-width:1;stroke:rgb(167,133,183);fill:none\"/><text x=\"335\" y=\"444\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Q (53746 ≅ 1.81%)</text><path  d=\"M 575 290\nL 487 412\nA 150 150 6.68 0 1 474 401\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(245,163,128)\"/><path  d=\"M 481 406\nL 471 455\nM 471 455\nL 456 455\" style=\"stroke-width:1;stroke:rgb(245,163,128);fill:none\"/><text x=\"349\" y=\"460\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">P (54792 ≅ 1.85%)</text><path  d=\"M 575 290\nL 502 421\nA 150 150 6.76 0 1 487 412\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(85,176,133)\"/><path  d=\"M 495 416\nL 487 471\nM 487 471\nL 472 471\" style=\"stroke-width:1;stroke:rgb(85,176,133);fill:none\"/><text x=\"365\" y=\"476\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">O (55486 ≅ 1.87%)</text><path  d=\"M 575 290\nL 519 429\nA 150 150 6.86 0 1 502 421\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(154,203,223)\"/><path  d=\"M 511 425\nL 504 487\nM 504 487\nL 489 487\" style=\"stroke-width:1;stroke:rgb(154,203,223);fill:none\"/><text x=\"389\" y=\"492\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">N (56306 ≅ 1.9%)</text><path  d=\"M 575 290\nL 536 435\nA 150 150 7.10 0 1 519 429\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(235,145,145)\"/><path  d=\"M 528 432\nL 523 503\nM 523 503\nL 508 503\" style=\"stroke-width:1;stroke:rgb(235,145,145);fill:none\"/><text x=\"398\" y=\"508\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">M (58270 ≅ 1.97%)</text><path  d=\"M 575 290\nL 555 439\nA 150 150 7.17 0 1 536 435\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(244,210,134)\"/><path  d=\"M 546 437\nL 543 519\nM 543 519\nL 528 519\" style=\"stroke-width:1;stroke:rgb(244,210,134);fill:none\"/><text x=\"422\" y=\"524\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">L (58818 ≅ 1.99%)</text><path  d=\"M 575 290\nL 578 440\nA 150 150 8.85 0 1 555 439\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(171,207,154)\"/><path  d=\"M 567 439\nL 566 535\nM 566 535\nL 551 535\" style=\"stroke-width:1;stroke:rgb(171,207,154);fill:none\"/><text x=\"444\" y=\"540\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">K (72586 ≅ 2.45%)</text><path  d=\"M 575 290\nL 425 291\nA 150 150 3.60 0 1 425 281\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(238,201,228)\"/><path  d=\"M 426 286\nL 411 279\nM 411 279\nL 396 279\" style=\"stroke-width:1;stroke:rgb(238,201,228);fill:none\"/><text x=\"298\" y=\"284\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AA (29558 ≅ 1%)</text><path  d=\"M 575 290\nL 425 281\nA 150 150 3.58 0 1 426 272\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(191,196,212)\"/><path  d=\"M 426 277\nL 411 263\nM 411 263\nL 396 263\" style=\"stroke-width:1;stroke:rgb(191,196,212);fill:none\"/><text x=\"281\" y=\"268\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AB (29384 ≅ 0.99%)</text><path  d=\"M 575 290\nL 426 272\nA 150 150 3.43 0 1 427 263\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(219,227,216)\"/><path  d=\"M 427 268\nL 412 247\nM 412 247\nL 397 247\" style=\"stroke-width:1;stroke:rgb(219,227,216);fill:none\"/><text x=\"282\" y=\"252\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AC (28166 ≅ 0.95%)</text><path  d=\"M 575 290\nL 427 263\nA 150 150 3.29 0 1 429 254\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(246,236,214)\"/><path  d=\"M 429 259\nL 414 231\nM 414 231\nL 399 231\" style=\"stroke-width:1;stroke:rgb(246,236,214);fill:none\"/><text x=\"284\" y=\"236\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AD (26998 ≅ 0.91%)</text><path  d=\"M 575 290\nL 429 254\nA 150 150 3.28 0 1 432 246\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(243,219,219)\"/><path  d=\"M 431 251\nL 416 215\nM 416 215\nL 401 215\" style=\"stroke-width:1;stroke:rgb(243,219,219);fill:none\"/><text x=\"287\" y=\"220\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AE (26948 ≅ 0.91%)</text><path  d=\"M 575 290\nL 432 246\nA 150 150 3.18 0 1 434 238\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(221,233,237)\"/><path  d=\"M 433 243\nL 419 199\nM 419 199\nL 404 199\" style=\"stroke-width:1;stroke:rgb(221,233,237);fill:none\"/><text x=\"290\" y=\"204\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AF (26054 ≅ 0.88%)</text><path  d=\"M 575 290\nL 434 238\nA 150 150 3.14 0 1 437 231\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(157,185,172)\"/><path  d=\"M 436 235\nL 422 183\nM 422 183\nL 407 183\" style=\"stroke-width:1;stroke:rgb(157,185,172);fill:none\"/><text x=\"291\" y=\"188\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AG (25804 ≅ 0.87%)</text><path  d=\"M 575 290\nL 437 231\nA 150 150 3.14 0 1 441 223\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(246,220,210)\"/><path  d=\"M 439 227\nL 426 167\nM 426 167\nL 411 167\" style=\"stroke-width:1;stroke:rgb(246,220,210);fill:none\"/><text x=\"295\" y=\"172\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AH (25730 ≅ 0.87%)</text><path  d=\"M 575 290\nL 441 223\nA 150 150 2.98 0 1 444 216\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(200,195,202)\"/><path  d=\"M 443 220\nL 430 151\nM 430 151\nL 415 151\" style=\"stroke-width:1;stroke:rgb(200,195,202);fill:none\"/><text x=\"304\" y=\"156\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AI (24438 ≅ 0.82%)</text><path  d=\"M 575 290\nL 444 216\nA 150 150 2.90 0 1 448 210\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(246,233,243)\"/><path  d=\"M 447 214\nL 434 135\nM 434 135\nL 419 135\" style=\"stroke-width:1;stroke:rgb(246,233,243);fill:none\"/><text x=\"312\" y=\"140\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AJ (23782 ≅ 0.8%)</text><path  d=\"M 575 290\nL 448 210\nA 150 150 2.79 0 1 452 204\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(123,142,198)\"/><path  d=\"M 451 207\nL 438 119\nM 438 119\nL 423 119\" style=\"stroke-width:1;stroke:rgb(123,142,198);fill:none\"/><text x=\"308\" y=\"124\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AK (22896 ≅ 0.77%)</text><path  d=\"M 575 290\nL 452 204\nA 150 150 2.61 0 1 456 198\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(171,207,154)\"/><path  d=\"M 455 201\nL 443 103\nM 443 103\nL 428 103\" style=\"stroke-width:1;stroke:rgb(171,207,154);fill:none\"/><text x=\"314\" y=\"108\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AL (21404 ≅ 0.72%)</text><path  d=\"M 575 290\nL 456 198\nA 150 150 52.28 0 1 575 140\nL 575 290\nZ\" style=\"stroke:none;fill:rgb(244,210,134)\"/><path  d=\"M 509 156\nL 503 87\nM 503 87\nL 488 87\" style=\"stroke-width:1;stroke:rgb(244,210,134);fill:none\"/><text x=\"355\" y=\"92\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">AM (428978 ≅ 14.52%)</text></svg>",
 			pngCRC: 0x14b2e7e0,
+		},
+		{
+			name: "pie_chart_with_value_formatter",
+			makeOptions: func() PieChartOption {
+				return PieChartOption{
+					SeriesList: NewSeriesListPie([]float64{
+						1048, 735, 580,
+					}, PieSeriesOption{
+						Names: []string{"A", "B", "C"},
+						Label: SeriesLabel{
+							Show: Ptr(true),
+							ValueFormatter: func(f float64) string {
+								return "ValueFormatter: " + humanize.FtoaWithDigits(f, 0)
+							},
+						},
+					}),
+				}
+			},
+			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 20 20\nL 580 20\nL 580 380\nL 20 380\nL 20 20\" style=\"stroke:none;fill:white\"/><path  d=\"M 217 23\nL 247 23\nL 247 36\nL 217 36\nL 217 23\" style=\"stroke:none;fill:rgb(84,112,198)\"/><text x=\"249\" y=\"35\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">A</text><path  d=\"M 280 23\nL 310 23\nL 310 36\nL 280 36\nL 280 23\" style=\"stroke:none;fill:rgb(145,204,117)\"/><text x=\"312\" y=\"35\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">B</text><path  d=\"M 342 23\nL 372 23\nL 372 36\nL 342 36\nL 342 23\" style=\"stroke:none;fill:rgb(250,200,88)\"/><text x=\"374\" y=\"35\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">C</text><path  d=\"M 300 218\nL 300 88\nA 130 130 159.66 0 1 345 340\nL 300 218\nZ\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 427 196\nL 442 193\nM 442 193\nL 457 193\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:none\"/><text x=\"460\" y=\"198\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">ValueFormatter: 1048</text><path  d=\"M 300 218\nL 345 340\nA 130 130 111.98 0 1 170 214\nL 300 218\nZ\" style=\"stroke:none;fill:rgb(145,204,117)\"/><path  d=\"M 225 323\nL 216 335\nM 216 335\nL 201 335\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:none\"/><text x=\"80\" y=\"340\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">ValueFormatter: 735</text><path  d=\"M 300 218\nL 170 214\nA 130 130 88.36 0 1 300 88\nL 300 218\nZ\" style=\"stroke:none;fill:rgb(250,200,88)\"/><path  d=\"M 210 126\nL 200 115\nM 200 115\nL 185 115\" style=\"stroke-width:1;stroke:rgb(250,200,88);fill:none\"/><text x=\"64\" y=\"120\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">ValueFormatter: 580</text></svg>",
+			pngCRC: 0x87b1a253,
+		},
+		{
+			name: "pie_chart_with_label_formatter_precedence",
+			makeOptions: func() PieChartOption {
+				return PieChartOption{
+					SeriesList: NewSeriesListPie([]float64{
+						1048, 735, 580,
+					}, PieSeriesOption{
+						Names: []string{"A", "B", "C"},
+						Label: SeriesLabel{
+							Show: Ptr(true),
+							ValueFormatter: func(f float64) string {
+								return "ValueFormatter: " + humanize.FtoaWithDigits(f, 0)
+							},
+							LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+								return "LabelFormatter: " + name + "=" + humanize.FtoaWithDigits(val, 0), nil
+							},
+						},
+					}),
+				}
+			},
+			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 20 20\nL 580 20\nL 580 380\nL 20 380\nL 20 20\" style=\"stroke:none;fill:white\"/><path  d=\"M 217 23\nL 247 23\nL 247 36\nL 217 36\nL 217 23\" style=\"stroke:none;fill:rgb(84,112,198)\"/><text x=\"249\" y=\"35\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">A</text><path  d=\"M 280 23\nL 310 23\nL 310 36\nL 280 36\nL 280 23\" style=\"stroke:none;fill:rgb(145,204,117)\"/><text x=\"312\" y=\"35\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">B</text><path  d=\"M 342 23\nL 372 23\nL 372 36\nL 342 36\nL 342 23\" style=\"stroke:none;fill:rgb(250,200,88)\"/><text x=\"374\" y=\"35\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">C</text><path  d=\"M 300 218\nL 300 88\nA 130 130 159.66 0 1 345 340\nL 300 218\nZ\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 427 196\nL 442 193\nM 442 193\nL 457 193\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:none\"/><text x=\"460\" y=\"198\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">LabelFormatter: A=1048</text><path  d=\"M 300 218\nL 345 340\nA 130 130 111.98 0 1 170 214\nL 300 218\nZ\" style=\"stroke:none;fill:rgb(145,204,117)\"/><path  d=\"M 225 323\nL 216 335\nM 216 335\nL 201 335\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:none\"/><text x=\"66\" y=\"340\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">LabelFormatter: B=735</text><path  d=\"M 300 218\nL 170 214\nA 130 130 88.36 0 1 300 88\nL 300 218\nZ\" style=\"stroke:none;fill:rgb(250,200,88)\"/><path  d=\"M 210 126\nL 200 115\nM 200 115\nL 185 115\" style=\"stroke-width:1;stroke:rgb(250,200,88);fill:none\"/><text x=\"50\" y=\"120\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">LabelFormatter: C=580</text></svg>",
+			pngCRC: 0xea07ff5b,
 		},
 		{
 			name: "custom_fonts",
@@ -312,6 +365,77 @@ func TestPieChart(t *testing.T) {
 			},
 			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 20 20\nL 580 20\nL 580 380\nL 20 380\nL 20 20\" style=\"stroke:none;fill:white\"/><path  d=\"M 300 200\nL 300 72\nA 128 128 119.89 0 1 411 264\nL 300 200\nZ\" style=\"stroke-width:4;stroke:white;fill:rgb(84,112,198)\"/><path  d=\"M 300 200\nL 411 264\nA 128 128 84.08 0 1 248 317\nL 300 200\nZ\" style=\"stroke-width:4;stroke:white;fill:rgb(145,204,117)\"/><path  d=\"M 300 200\nL 248 317\nA 128 128 66.35 0 1 172 199\nL 300 200\nZ\" style=\"stroke-width:4;stroke:white;fill:rgb(250,200,88)\"/><path  d=\"M 300 200\nL 172 199\nA 128 128 55.37 0 1 228 94\nL 300 200\nZ\" style=\"stroke-width:4;stroke:white;fill:rgb(238,102,102)\"/><path  d=\"M 300 200\nL 228 94\nA 128 128 34.32 0 1 300 72\nL 300 200\nZ\" style=\"stroke-width:4;stroke:white;fill:rgb(115,192,222)\"/></svg>",
 			pngCRC: 0xde32ca61,
+		},
+		{
+			name: "mixed_label_style",
+			makeOptions: func() PieChartOption {
+				return PieChartOption{
+					SeriesList: NewSeriesListPie([]float64{
+						1048, 735, 580, 484, 300,
+					}, PieSeriesOption{
+						Names: []string{"Visible", "Hidden", "Styled", "Hidden", "Custom"},
+						Label: SeriesLabel{
+							Show: Ptr(true),
+							LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+								switch index {
+								case 0: // first - simple visible
+									return name + ": " + strconv.FormatFloat(val, 'f', 0, 64), nil
+								case 1, 3: // second and fourth - hidden
+									return "", nil
+								case 2: // third - styled with background
+									return "📊 " + name, &LabelStyle{
+										FontStyle:       FontStyle{FontColor: ColorWhite, FontSize: 13},
+										BackgroundColor: ColorPurple,
+										CornerRadius:    4,
+									}
+								default: // last - custom color only
+									return name + " ★", &LabelStyle{
+										FontStyle: FontStyle{FontColor: ColorGreen, FontSize: 14},
+									}
+								}
+							},
+						},
+					}),
+					Title: TitleOption{
+						Show: Ptr(false),
+					},
+					Legend: LegendOption{
+						Show: Ptr(false),
+					},
+				}
+			},
+			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 20 20\nL 580 20\nL 580 380\nL 20 380\nL 20 20\" style=\"stroke:none;fill:white\"/><path  d=\"M 300 200\nL 300 56\nA 144 144 119.89 0 1 425 272\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 424 128\nL 437 121\nM 437 121\nL 452 121\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:none\"/><text x=\"455\" y=\"126\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">Visible: 1048</text><path  d=\"M 300 200\nL 425 272\nA 144 144 84.08 0 1 242 332\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(145,204,117)\"/><path  d=\"M 300 200\nL 242 332\nA 144 144 66.35 0 1 156 199\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(250,200,88)\"/><path  d=\"M 180 278\nL 167 286\nM 167 286\nL 152 286\" style=\"stroke-width:1;stroke:rgb(250,200,88);fill:none\"/><path  d=\"M 100 270\nL 164 270\nL 164 270\nA 4 4 90.00 0 1 168 274\nL 168 291\nL 168 291\nA 4 4 90.00 0 1 164 295\nL 100 295\nL 100 295\nA 4 4 90.00 0 1 96 291\nL 96 274\nL 96 274\nA 4 4 90.00 0 1 100 270\nZ\" style=\"stroke:none;fill:purple\"/><text x=\"100\" y=\"291\" style=\"stroke:none;fill:white;font-size:16.6px;font-family:'Roboto Medium',sans-serif\">📊 Styled</text><path  d=\"M 300 200\nL 156 199\nA 144 144 55.37 0 1 219 81\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(238,102,102)\"/><path  d=\"M 300 200\nL 219 81\nA 144 144 34.32 0 1 300 56\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(115,192,222)\"/><path  d=\"M 258 63\nL 254 49\nM 254 49\nL 239 49\" style=\"stroke-width:1;stroke:rgb(115,192,222);fill:none\"/><text x=\"178\" y=\"54\" style=\"stroke:none;fill:green;font-size:17.9px;font-family:'Roboto Medium',sans-serif\">Custom ★</text></svg>",
+			pngCRC: 0x816bb9bd,
+		},
+		{
+			name: "border_styling",
+			makeOptions: func() PieChartOption {
+				values := []float64{100, 200, 150}
+				opt := NewPieChartOptionWithData(values)
+				opt.SeriesList[0].Label = SeriesLabel{
+					Show: Ptr(true),
+					LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+						return "background", &LabelStyle{
+							BackgroundColor: ColorBlue,
+							BorderColor:     ColorRed,
+							BorderWidth:     2,
+							CornerRadius:    5,
+						}
+					},
+				}
+				opt.SeriesList[1].Label = SeriesLabel{
+					Show: Ptr(true),
+					LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+						return "transparent", &LabelStyle{
+							BorderColor: ColorGreen,
+							BorderWidth: 1.5,
+						}
+					},
+				}
+				return opt
+			},
+			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 20 20\nL 580 20\nL 580 380\nL 20 380\nL 20 20\" style=\"stroke:none;fill:white\"/><path  d=\"M 300 200\nL 300 72\nA 128 128 80.00 0 1 426 178\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(84,112,198)\"/><path  d=\"M 382 102\nL 391 91\nM 391 91\nL 406 91\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:none\"/><path  d=\"M 410 79\nL 476 79\nL 476 79\nA 5 5 90.00 0 1 481 84\nL 481 95\nL 481 95\nA 5 5 90.00 0 1 476 100\nL 410 100\nL 410 100\nA 5 5 90.00 0 1 405 95\nL 405 84\nL 405 84\nA 5 5 90.00 0 1 410 79\nZ\" style=\"stroke-width:2;stroke:red;fill:blue\"/><text x=\"409\" y=\"96\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">background</text><path  d=\"M 300 200\nL 426 178\nA 128 128 160.00 0 1 189 264\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(145,204,117)\"/><path  d=\"M 343 320\nL 348 334\nM 348 334\nL 363 334\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:none\"/><path  d=\"M 362 322\nL 437 322\nL 437 343\nL 362 343\nL 362 322\" style=\"stroke-width:1.5;stroke:green;fill:none\"/><text x=\"366\" y=\"339\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">transparent</text><path  d=\"M 300 200\nL 189 264\nA 128 128 120.00 0 1 300 72\nL 300 200\nZ\" style=\"stroke:none;fill:rgb(250,200,88)\"/><path  d=\"M 190 137\nL 177 75\nM 177 75\nL 162 75\" style=\"stroke-width:1;stroke:rgb(250,200,88);fill:none\"/><text x=\"110\" y=\"80\" style=\"stroke:none;fill:rgb(70,70,70);font-size:12.8px;font-family:'Roboto Medium',sans-serif\">: 33.33%</text></svg>",
+			pngCRC: 0x69eb0e9d,
 		},
 	}
 

--- a/range.go
+++ b/range.go
@@ -253,7 +253,7 @@ func calculateValueAxisRange(p *Painter, isVertical bool, axisSize int,
 	}
 }
 
-// calculateCategoryAxisRange does the same for category axes (common for X-axis in line/bar charts).
+// calculateCategoryAxisRange does the same for category axes (common for x-axis in line/bar charts).
 func calculateCategoryAxisRange(p *Painter, axisSize int, isVertical bool, extraSpace bool,
 	labels []string, dataStartIndex int,
 	labelCountCfg int, labelCountAdjustment int, labelUnit float64,

--- a/scatter_chart.go
+++ b/scatter_chart.go
@@ -129,11 +129,10 @@ func (s *scatterChart) renderChart(result *defaultRenderResult) (Box, error) {
 				}
 				if labelPainter != nil {
 					labelPainter.Add(labelValue{
-						index:     index,
-						value:     item,
-						x:         p.X,
-						y:         p.Y,
-						fontStyle: series.Label.FontStyle,
+						index: index,
+						value: item,
+						x:     p.X,
+						y:     p.Y,
 					})
 				}
 			}

--- a/scatter_chart_test.go
+++ b/scatter_chart_test.go
@@ -411,6 +411,60 @@ func TestScatterChart(t *testing.T) {
 			svg:    "",
 			pngCRC: 0,
 		},
+		{
+			name: "with_conditional_labels",
+			makeOptions: func() ScatterChartOption {
+				return ScatterChartOption{
+					Padding: NewBoxEqual(10),
+					XAxis: XAxisOption{
+						Labels: []string{"A", "B", "C", "D", "E"},
+					},
+					YAxis: []YAxisOption{{}},
+					SeriesList: NewSeriesListScatter([][]float64{
+						{50, 150, 100, 200, 175},
+						{75, 125, 90, 160, 140},
+					}, ScatterSeriesOption{
+						Names: []string{"Dataset1", "Dataset2"},
+						Label: SeriesLabel{
+							Show: Ptr(true),
+							LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+								// Show labels only for values above 120
+								if val > 120 {
+									switch {
+									case val >= 180: // High values - gold styling
+										return "⭐ " + strconv.FormatFloat(val, 'f', 0, 64), &LabelStyle{
+											FontStyle:       FontStyle{FontColor: ColorBlack, FontSize: 14},
+											BackgroundColor: ColorFromHex("#FFD700"), // Gold
+											CornerRadius:    6,
+										}
+									case val >= 150: // Medium-high values - silver styling
+										return "📊 " + strconv.FormatFloat(val, 'f', 0, 64), &LabelStyle{
+											FontStyle:       FontStyle{FontColor: ColorBlack, FontSize: 12},
+											BackgroundColor: ColorFromHex("#C0C0C0"), // Silver
+											CornerRadius:    4,
+										}
+									default: // Values above 120 but below 150 - simple styling
+										return strconv.FormatFloat(val, 'f', 0, 64), &LabelStyle{
+											FontStyle: FontStyle{FontColor: ColorBlue, FontSize: 10},
+										}
+									}
+								}
+								// Hide labels for values <= 120
+								return "", nil
+							},
+						},
+					}),
+					Title: TitleOption{
+						Show: Ptr(false),
+					},
+					Legend: LegendOption{
+						Show: Ptr(false),
+					},
+				}
+			},
+			svg:    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 600 400\"><path  d=\"M 0 0\nL 600 0\nL 600 400\nL 0 400\nL 0 0\" style=\"stroke:none;fill:white\"/><text x=\"9\" y=\"16\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">230</text><text x=\"9\" y=\"55\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">210</text><text x=\"9\" y=\"94\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">190</text><text x=\"9\" y=\"133\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">170</text><text x=\"9\" y=\"172\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">150</text><text x=\"9\" y=\"211\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">130</text><text x=\"9\" y=\"250\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">110</text><text x=\"18\" y=\"289\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">90</text><text x=\"18\" y=\"328\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">70</text><text x=\"18\" y=\"368\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">50</text><path  d=\"M 42 10\nL 590 10\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 42 49\nL 590 49\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 42 88\nL 590 88\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 42 128\nL 590 128\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 42 167\nL 590 167\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 42 206\nL 590 206\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 42 246\nL 590 246\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 42 285\nL 590 285\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 42 324\nL 590 324\" style=\"stroke-width:1;stroke:rgb(224,230,242);fill:none\"/><path  d=\"M 46 364\nL 590 364\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 46 369\nL 46 364\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 182 369\nL 182 364\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 318 369\nL 318 364\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 454 369\nL 454 364\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><path  d=\"M 590 369\nL 590 364\" style=\"stroke-width:1;stroke:rgb(110,112,121);fill:none\"/><text x=\"45\" y=\"390\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">A</text><text x=\"181\" y=\"390\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">B</text><text x=\"317\" y=\"390\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">C</text><text x=\"453\" y=\"390\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">D</text><text x=\"581\" y=\"390\" style=\"stroke:none;fill:rgb(70,70,70);font-size:15.3px;font-family:'Roboto Medium',sans-serif\">E</text><circle cx=\"46\" cy=\"364\" r=\"2\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:rgb(84,112,198)\"/><circle cx=\"182\" cy=\"168\" r=\"2\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:rgb(84,112,198)\"/><circle cx=\"318\" cy=\"266\" r=\"2\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:rgb(84,112,198)\"/><circle cx=\"454\" cy=\"69\" r=\"2\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:rgb(84,112,198)\"/><circle cx=\"590\" cy=\"119\" r=\"2\" style=\"stroke-width:1;stroke:rgb(84,112,198);fill:rgb(84,112,198)\"/><circle cx=\"46\" cy=\"315\" r=\"2\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:rgb(145,204,117)\"/><circle cx=\"182\" cy=\"217\" r=\"2\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:rgb(145,204,117)\"/><circle cx=\"318\" cy=\"286\" r=\"2\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:rgb(145,204,117)\"/><circle cx=\"454\" cy=\"148\" r=\"2\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:rgb(145,204,117)\"/><circle cx=\"590\" cy=\"187\" r=\"2\" style=\"stroke-width:1;stroke:rgb(145,204,117);fill:rgb(145,204,117)\"/><path  d=\"M 187 154\nL 229 154\nL 229 154\nA 4 4 90.00 0 1 233 158\nL 233 174\nL 233 174\nA 4 4 90.00 0 1 229 178\nL 187 178\nL 187 178\nA 4 4 90.00 0 1 183 174\nL 183 158\nL 183 158\nA 4 4 90.00 0 1 187 154\nZ\" style=\"stroke:none;fill:silver\"/><text x=\"187\" y=\"174\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">📊 150</text><path  d=\"M 461 54\nL 506 54\nL 506 54\nA 6 6 90.00 0 1 512 60\nL 512 74\nL 512 74\nA 6 6 90.00 0 1 506 80\nL 461 80\nL 461 80\nA 6 6 90.00 0 1 455 74\nL 455 60\nL 455 60\nA 6 6 90.00 0 1 461 54\nZ\" style=\"stroke:none;fill:rgb(255,215,0)\"/><text x=\"459\" y=\"76\" style=\"stroke:none;fill:black;font-size:17.9px;font-family:'Roboto Medium',sans-serif\">⭐ 200</text><path  d=\"M 595 105\nL 637 105\nL 637 105\nA 4 4 90.00 0 1 641 109\nL 641 125\nL 641 125\nA 4 4 90.00 0 1 637 129\nL 595 129\nL 595 129\nA 4 4 90.00 0 1 591 125\nL 591 109\nL 591 109\nA 4 4 90.00 0 1 595 105\nZ\" style=\"stroke:none;fill:silver\"/><text x=\"595\" y=\"125\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">📊 175</text><text x=\"187\" y=\"221\" style=\"stroke:none;fill:blue;font-size:12.8px;font-family:'Roboto Medium',sans-serif\">125</text><path  d=\"M 459 134\nL 501 134\nL 501 134\nA 4 4 90.00 0 1 505 138\nL 505 154\nL 505 154\nA 4 4 90.00 0 1 501 158\nL 459 158\nL 459 158\nA 4 4 90.00 0 1 455 154\nL 455 138\nL 455 138\nA 4 4 90.00 0 1 459 134\nZ\" style=\"stroke:none;fill:silver\"/><text x=\"459\" y=\"154\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">📊 160</text><text x=\"595\" y=\"191\" style=\"stroke:none;fill:blue;font-size:12.8px;font-family:'Roboto Medium',sans-serif\">140</text></svg>",
+			pngCRC: 0xfca17cb5,
+		},
 	}
 
 	for i, tt := range tests {

--- a/series.go
+++ b/series.go
@@ -9,24 +9,61 @@ import (
 	"github.com/go-analyze/charts/chartdraw"
 )
 
-// SeriesLabel specifies if and how the individual series values are rendered on the chart.
+// SeriesLabel configures how individual data point labels are rendered on charts.
 type SeriesLabel struct {
-	// FormatTemplate is a string template for formatting the data label.
-	// {b}: the name of a data item.
-	// {c}: the value of a data item.
-	// {d}: the percent of a data item (pie chart).
-	FormatTemplate string
-	// ValueFormatter provides an alternative method for formatting data labels.
-	ValueFormatter ValueFormatter
-	// FontStyle specifies the font and style for the label.
-	FontStyle FontStyle
-	// Show controls label visibility. If unset, behavior defaults based on the chart type.
+	// Show controls whether data labels are displayed for this series.
+	// Use Ptr(true) to show labels, Ptr(false) to hide them, or nil for chart-specific defaults.
 	Show *bool
+	// LabelFormatter provides complete control over label content and per-point styling.
+	// When set, this takes precedence for label production.
+	LabelFormatter SeriesLabelFormatter
+	// Deprecated: FormatTemplate is deprecated, use LabelFormatter instead for better control.
+	// Template string for formatting data labels with placeholders:
+	//   {b}: the name of the data item
+	//   {c}: the value of the data item
+	//   {d}: the percentage of the data item (pie/doughnut charts only)
+	// Example: "{b}: {c} ({d})" produces "Sales: 150 (25%)"
+	FormatTemplate string
+	// ValueFormatter functions as the simplest method of number formatting or customization.
+	// Only utilized when other methods are not set.
+	ValueFormatter ValueFormatter
+	// FontStyle specifies the default font styling for labels in this series.
+	// Individual labels can override this via LabelFormatter's LabelStyle return value.
+	FontStyle FontStyle
 	// Distance specifies the pixel distance between the label and its associated data point or chart element.
 	Distance int // TODO - do we want to replace with just Offset?
 	// Offset specifies an offset from the position.
 	Offset OffsetInt
 }
+
+// LabelStyle contains optional styling overrides for individual label rendering.
+// All fields are optional - zero values mean "use default styling from series or theme".
+type LabelStyle struct {
+	// FontStyle overrides font properties (color, size, family) for this specific label.
+	FontStyle FontStyle
+	// BackgroundColor provides a background color behind the label text.
+	BackgroundColor Color
+	// CornerRadius sets the radius for rounded corners on the background rectangle.
+	CornerRadius int
+	// BorderColor sets the border color around the label background.
+	BorderColor Color
+	// BorderWidth sets the width of the border around the label background.
+	BorderWidth float64
+}
+
+// SeriesLabelFormatter is a function that generates custom labels with optional per-point styling.
+// This provides full control over label content and appearance for each data point.
+//
+// Parameters:
+//   - index: The data point index within the series
+//   - name: The series name for this data point
+//   - val: The numeric value for this data point
+//
+// Returns:
+//   - string: The label text to display. Return "" to hide the label for this point
+//   - *LabelStyle: Optional styling override for this specific label. Return nil
+//     to use default series/theme styling.
+type SeriesLabelFormatter func(index int, name string, val float64) (string, *LabelStyle)
 
 const (
 	SeriesMarkTypeMax      = "max"

--- a/series_label.go
+++ b/series_label.go
@@ -1,17 +1,195 @@
 package charts
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/dustin/go-humanize"
 )
 
+var (
+	// LabelFormatterValueShort provides a short value with at most 2 decimal places.
+	LabelFormatterValueShort = func(index int, name string, val float64) (string, *LabelStyle) {
+		return defaultValueFormatter(val), nil
+	}
+
+	// LabelFormatterNameShortValue puts the series name next to the value with up to 2 decimal places.
+	LabelFormatterNameShortValue = func(index int, name string, val float64) (string, *LabelStyle) {
+		return name + ": " + defaultValueFormatter(val), nil
+	}
+)
+
+// LabelFormatterThresholdMin returns a SeriesLabelFormatter that only shows labels for values above the specified threshold.
+// Values at or below the threshold will have empty labels (effectively hiding them).
+func LabelFormatterThresholdMin(threshold float64) SeriesLabelFormatter {
+	return func(index int, name string, val float64) (string, *LabelStyle) {
+		if val >= threshold {
+			return defaultValueFormatter(val), nil
+		}
+		return "", nil
+	}
+}
+
+// LabelFormatterThresholdMax returns a SeriesLabelFormatter that only shows labels for values at or below the specified threshold.
+// Values above the threshold will have empty labels (effectively hiding them).
+func LabelFormatterThresholdMax(threshold float64) SeriesLabelFormatter {
+	return func(index int, name string, val float64) (string, *LabelStyle) {
+		if val <= threshold {
+			return defaultValueFormatter(val), nil
+		}
+		return "", nil
+	}
+}
+
+// LabelFormatterTopN returns a SeriesLabelFormatter that only shows labels for the top N highest values in the provided slice.
+// This formatter requires the complete data values to determine which values are in the top N.
+func LabelFormatterTopN(values []float64, n int) SeriesLabelFormatter {
+	if n <= 0 {
+		return func(index int, name string, val float64) (string, *LabelStyle) {
+			return "", nil
+		}
+	} else if len(values) <= n {
+		return LabelFormatterValueShort // Threshold below minimum, show all values
+	}
+
+	// Sort values in ascending order to find the nth highest
+	sortedValues := make([]float64, len(values))
+	copy(sortedValues, values)
+	sort.Float64s(sortedValues)
+
+	// set threshold to the nth highest (from the end of ascending sorted slice)
+	threshold := sortedValues[len(sortedValues)-n]
+	return LabelFormatterThresholdMin(threshold)
+}
+
+// LabelFormatterGradientGreenRed returns a SeriesLabelFormatter that colors labels from green (minimum) to red (maximum).
+// This formatter requires the complete data values to determine the min/max range for color interpolation.
+func LabelFormatterGradientGreenRed(values []float64) SeriesLabelFormatter {
+	return LabelFormatterGradientColor(values, ColorGreen, ColorYellowAlt1, ColorRed)
+}
+
+// LabelFormatterGradientRedGreen returns a SeriesLabelFormatter that colors labels from red (minimum) to green (maximum).
+// This formatter requires the complete data values to determine the min/max range for color interpolation.
+func LabelFormatterGradientRedGreen(values []float64) SeriesLabelFormatter {
+	return LabelFormatterGradientColor(values, ColorRed, ColorYellowAlt1, ColorGreen)
+}
+
+// LabelFormatterGradientColor returns a SeriesLabelFormatter that colors labels with a gradient between multiple colors.
+// The minimum value gets the first color, maximum value gets the last color, and intermediate values are interpolated.
+// For two colors: lowColor -> highColor. For three+ colors: first -> second -> ... -> last.
+// This formatter requires the complete data values to determine the min/max range for color interpolation.
+func LabelFormatterGradientColor(values []float64, colors ...Color) SeriesLabelFormatter {
+	// Handle case where no colors are provided
+	if len(colors) == 0 {
+		colors = []Color{ColorBlack} // default to black
+	}
+
+	summary := summarizePopulationData(values)
+	minVal, maxVal := summary.Min, summary.Max
+
+	// Handle edge case where all values are the same
+	if minVal == maxVal {
+		return func(index int, name string, val float64) (string, *LabelStyle) {
+			return defaultValueFormatter(val), &LabelStyle{
+				FontStyle: FontStyle{FontColor: colors[0]},
+			}
+		}
+	}
+
+	return func(index int, name string, val float64) (string, *LabelStyle) {
+		// Calculate the interpolation factor (0.0 = min, 1.0 = max)
+		factor := (val - minVal) / (maxVal - minVal)
+		if factor < 0 {
+			factor = 0
+		} else if factor > 1 {
+			factor = 1
+		}
+
+		// Interpolate between the colors
+		interpolatedColor := interpolateMultipleColors(colors, factor)
+
+		return defaultValueFormatter(val), &LabelStyle{
+			FontStyle: FontStyle{FontColor: interpolatedColor},
+		}
+	}
+}
+
+// interpolateColor linearly interpolates between two colors.
+// factor should be between 0.0 (returns color1) and 1.0 (returns color2).
+func interpolateColor(color1, color2 Color, factor float64) Color {
+	if factor < 0 {
+		factor = 0
+	} else if factor > 1 {
+		factor = 1
+	}
+
+	r1, g1, b1, a1 := color1.RGBA()
+	r2, g2, b2, a2 := color2.RGBA()
+
+	// Convert from 16-bit to 8-bit values
+	r1, g1, b1, a1 = r1>>8, g1>>8, b1>>8, a1>>8
+	r2, g2, b2, a2 = r2>>8, g2>>8, b2>>8, a2>>8
+
+	// Interpolate each component
+	r := uint8(float64(r1) + factor*float64(int(r2)-int(r1)))
+	g := uint8(float64(g1) + factor*float64(int(g2)-int(g1)))
+	b := uint8(float64(b1) + factor*float64(int(b2)-int(b1)))
+	a := uint8(float64(a1) + factor*float64(int(a2)-int(a1)))
+
+	return Color{R: r, G: g, B: b, A: a}
+}
+
+// interpolateMultipleColors interpolates between multiple colors based on a factor (0.0 to 1.0).
+// For a single color, returns that color.
+// For two colors, behaves like interpolateColor.
+// For three+ colors, divides the factor range equally between color segments.
+func interpolateMultipleColors(colors []Color, factor float64) Color {
+	if len(colors) == 0 {
+		return ColorBlack // fallback
+	}
+	if len(colors) == 1 {
+		return colors[0]
+	}
+	// Clamp factor to [0, 1] range for all cases
+	if factor < 0 {
+		factor = 0
+	} else if factor > 1 {
+		factor = 1
+	}
+
+	if len(colors) == 2 {
+		return interpolateColor(colors[0], colors[1], factor)
+	}
+
+	// For 3+ colors, divide the factor range into segments
+	numSegments := len(colors) - 1
+	segmentSize := 1.0 / float64(numSegments)
+
+	// Find which segment the factor falls into
+	segmentIndex := int(factor / segmentSize)
+
+	// Handle edge case where factor is exactly 1.0
+	if segmentIndex >= numSegments {
+		segmentIndex = numSegments - 1
+	}
+
+	// Calculate the local factor within this segment (0.0 to 1.0)
+	localFactor := (factor - float64(segmentIndex)*segmentSize) / segmentSize
+
+	// Interpolate between the two colors in this segment
+	return interpolateColor(colors[segmentIndex], colors[segmentIndex+1], localFactor)
+}
+
 type labelRenderValue struct {
-	Text      string
-	FontStyle FontStyle
-	X         int
-	Y         int
-	Radians   float64
+	text            string
+	fontStyle       FontStyle
+	x               int
+	y               int
+	radians         float64
+	backgroundColor Color
+	cornerRadius    int
+	borderColor     Color
+	borderWidth     float64
 }
 
 type labelValue struct {
@@ -53,80 +231,152 @@ func (o *seriesLabelPainter) Add(value labelValue) {
 		distance = 5
 	}
 	var text string
-	if label.ValueFormatter != nil && label.FormatTemplate == "" {
-		text = label.ValueFormatter(value.value)
+	var labelStyleOverride *LabelStyle
+	if label.LabelFormatter != nil {
+		var name string
+		if len(o.seriesNames) > value.index {
+			name = o.seriesNames[value.index]
+		}
+		text, labelStyleOverride = label.LabelFormatter(value.index, name, value.value)
 	} else {
-		text = labelFormatValue(o.seriesNames, label.FormatTemplate, label.ValueFormatter,
-			value.index, value.value, -1)
+		if label.ValueFormatter == nil {
+			label.ValueFormatter = defaultValueFormatter
+		}
+		if label.FormatTemplate != "" {
+			text = labelFormatValue(o.seriesNames, label.FormatTemplate, label.ValueFormatter,
+				value.index, value.value, -1)
+		} else {
+			text = label.ValueFormatter(value.value)
+		}
 	}
-	labelStyle := FontStyle{
+	if text == "" {
+		return // nothing to render
+	}
+
+	labelFontStyle := mergeFontStyles(label.FontStyle, value.fontStyle, FontStyle{
 		FontColor: o.theme.GetLabelTextColor(),
 		FontSize:  defaultLabelFontSize,
 		Font:      getPreferredFont(label.FontStyle.Font, value.fontStyle.Font),
+	})
+	if labelStyleOverride != nil { // Prefer per-point style overrides if present
+		labelFontStyle = mergeFontStyles(labelStyleOverride.FontStyle, labelFontStyle)
 	}
-	if label.FontStyle.FontSize != 0 {
-		labelStyle.FontSize = label.FontStyle.FontSize
-	} else if value.fontStyle.FontSize != 0 {
-		labelStyle.FontSize = value.fontStyle.FontSize
-	}
-	if !label.FontStyle.FontColor.IsZero() {
-		labelStyle.FontColor = label.FontStyle.FontColor
-	} else if !value.fontStyle.FontColor.IsZero() {
-		labelStyle.FontColor = value.fontStyle.FontColor
-	}
-	p := o.p
-	textBox := p.MeasureText(text, value.radians, labelStyle)
+
+	textBox := o.p.MeasureText(text, value.radians, labelFontStyle)
 	renderValue := labelRenderValue{
-		Text:      text,
-		FontStyle: labelStyle,
-		X:         value.x,
-		Y:         value.y,
-		Radians:   value.radians,
+		text:      text,
+		fontStyle: labelFontStyle,
+		x:         value.x,
+		y:         value.y,
+		radians:   value.radians,
+	}
+
+	// Set background color, corner radius, and border styling if specified
+	if labelStyleOverride != nil {
+		renderValue.backgroundColor = labelStyleOverride.BackgroundColor
+		renderValue.cornerRadius = labelStyleOverride.CornerRadius
+		renderValue.borderColor = labelStyleOverride.BorderColor
+		renderValue.borderWidth = labelStyleOverride.BorderWidth
 	}
 	if value.vertical {
-		renderValue.X -= textBox.Width() >> 1
-		renderValue.Y -= distance
+		renderValue.x -= textBox.Width() >> 1
+		renderValue.y -= distance
 	} else {
-		renderValue.X += distance
-		renderValue.Y += textBox.Height() >> 1
-		renderValue.Y -= 2
+		renderValue.x += distance
+		renderValue.y += textBox.Height() >> 1
+		renderValue.y -= 2
 	}
 	if value.radians != 0 {
-		renderValue.X = value.x + (textBox.Width() >> 1) - 1
+		renderValue.x = value.x + (textBox.Width() >> 1) - 1
 	}
-	renderValue.X += value.offset.Left
-	renderValue.Y += value.offset.Top
+	renderValue.x += value.offset.Left
+	renderValue.y += value.offset.Top
 	o.values = append(o.values, renderValue)
+}
+
+// drawLabelWithBackground draws a text label with optional background styling.
+// This helper function can be used by various chart types to render labels with custom styling.
+//
+// Parameters:
+//   - p: The painter instance to draw on
+//   - text: The text to render (empty strings are ignored)
+//   - x, y: Text position coordinates
+//   - radians: Text rotation angle in radians
+//   - fontStyle: Font styling for the text
+//   - backgroundColor: Background color (transparent colors are ignored)
+//   - cornerRadius: Corner radius for background rectangle (negative values are treated as 0)
+//   - borderColor: Border color around the background (transparent colors are ignored)
+//   - borderWidth: Width of the border around the background (values <= 0 are ignored)
+func drawLabelWithBackground(p *Painter, text string, x, y int, radians float64, fontStyle FontStyle,
+	backgroundColor Color, cornerRadius int, borderColor Color, borderWidth float64) {
+	if text == "" {
+		return
+	}
+
+	if cornerRadius < 0 {
+		cornerRadius = 0
+	}
+
+	if !backgroundColor.IsTransparent() || (!borderColor.IsTransparent() && borderWidth > 0) {
+		textBox := p.MeasureText(text, radians, fontStyle)
+
+		const padding = 4
+		bgBox := Box{
+			Left:   x - padding,
+			Top:    y - textBox.Height() - padding,
+			Right:  x + textBox.Width() + padding,
+			Bottom: y + padding,
+		}
+
+		if cornerRadius > 0 {
+			// Clamp corner radius to prevent visual artifacts
+			boxWidth := bgBox.Width() / 2
+			boxHeight := bgBox.Height() / 2
+			maxRadius := boxWidth
+			if boxHeight < boxWidth {
+				maxRadius = boxHeight
+			}
+			if cornerRadius > maxRadius {
+				cornerRadius = maxRadius
+			}
+			p.roundedRect(bgBox, cornerRadius, true, true, backgroundColor, borderColor, borderWidth)
+		} else {
+			p.FilledRect(bgBox.Left, bgBox.Top, bgBox.Right, bgBox.Bottom, backgroundColor, borderColor, borderWidth)
+		}
+	}
+
+	p.Text(text, x, y, radians, fontStyle)
 }
 
 func (o *seriesLabelPainter) Render() (Box, error) {
 	for _, item := range o.values {
-		if item.Text != "" {
-			o.p.Text(item.Text, item.X, item.Y, item.Radians, item.FontStyle)
+		if item.text != "" {
+			drawLabelWithBackground(o.p, item.text, item.x, item.y, item.radians,
+				item.fontStyle, item.backgroundColor, item.cornerRadius, item.borderColor, item.borderWidth)
 		}
 	}
 	return BoxZero, nil
 }
 
-// labelFormatPie formats the value for a pie chart label.
-func labelFormatPie(seriesNames []string, layout string, valueFormatter ValueFormatter,
-	index int, value float64, percent float64) string {
+// Deprecated: labelFormatPie is deprecated.
+func labelFormatPie(seriesName string, layout string, valueFormatter ValueFormatter,
+	value float64, percent float64) string {
 	if len(layout) == 0 {
 		layout = "{b}: {d}"
 	}
-	return newLabelFormatter(seriesNames, layout, valueFormatter)(index, value, percent)
+	return newLabelFormatter([]string{seriesName}, layout, valueFormatter)(0, value, percent)
 }
 
-// labelFormatFunnel formats the value for a funnel chart label.
-func labelFormatFunnel(seriesNames []string, layout string, valueFormatter ValueFormatter,
-	index int, value float64, percent float64) string {
+// Deprecated: labelFormatFunnel is deprecated.
+func labelFormatFunnel(seriesName string, layout string, valueFormatter ValueFormatter,
+	value float64, percent float64) string {
 	if len(layout) == 0 {
 		layout = "{b}({d})"
 	}
-	return newLabelFormatter(seriesNames, layout, valueFormatter)(index, value, percent)
+	return newLabelFormatter([]string{seriesName}, layout, valueFormatter)(0, value, percent)
 }
 
-// labelFormatValue returns a formatted value.
+// Deprecated: labelFormatValue is deprecated.
 func labelFormatValue(seriesNames []string, layout string, valueFormatter ValueFormatter,
 	index int, value float64, percent float64) string {
 	if len(layout) == 0 {
@@ -135,12 +385,10 @@ func labelFormatValue(seriesNames []string, layout string, valueFormatter ValueF
 	return newLabelFormatter(seriesNames, layout, valueFormatter)(index, value, percent)
 }
 
-// newLabelFormatter returns a label formatter.
+// Deprecated: newLabelFormatter is deprecated.
 func newLabelFormatter(seriesNames []string, layout string, valueFormatter ValueFormatter) func(index int, value float64, percent float64) string {
 	if valueFormatter == nil {
-		valueFormatter = func(f float64) string {
-			return humanize.FtoaWithDigits(f, 2)
-		}
+		valueFormatter = defaultValueFormatter
 	}
 	return func(index int, value, percent float64) string {
 		var percentText string

--- a/series_label_test.go
+++ b/series_label_test.go
@@ -1,39 +1,36 @@
 package charts
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-analyze/charts/chartdraw/matrix"
 )
 
 func TestLabelFormatPie(t *testing.T) {
 	t.Parallel()
 
 	assert.Equal(t, "a: 12%",
-		labelFormatPie([]string{"a", "b"}, "", nil, 0, 10, 0.12))
-
-	assert.Equal(t, "b: 25%",
-		labelFormatPie([]string{"a", "b"}, "", nil, 1, 20, 0.25))
+		labelFormatPie("a", "", nil, 10, 0.12))
 
 	assert.Equal(t, "a: f",
-		labelFormatPie([]string{"a", "b"}, "{b}: {c}", func(f float64) string {
+		labelFormatPie("a", "{b}: {c}", func(f float64) string {
 			return "f"
-		}, 0, 10, 0.12))
+		}, 10, 0.12))
 }
 
 func TestLabelFormatFunnel(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "a(12%)",
-		labelFormatFunnel([]string{"a", "b"}, "", nil, 0, 10, 0.12))
-
-	assert.Equal(t, "b(25%)",
-		labelFormatFunnel([]string{"a", "b"}, "", nil, 1, 20, 0.25))
+	assert.Equal(t, "a(12%)", labelFormatFunnel("a", "", nil, 10, 0.12))
 
 	assert.Equal(t, "b(f, 25%)",
-		labelFormatFunnel([]string{"a", "b"}, "{b}({c}, {d})", func(f float64) string {
+		labelFormatFunnel("b", "{b}({c}, {d})", func(f float64) string {
 			return "f"
-		}, 1, 20, 0.25))
+		}, 20, 0.25))
 }
 
 func TestLabelFormatter(t *testing.T) {
@@ -50,14 +47,1148 @@ func TestLabelFormatter(t *testing.T) {
 			0, 10, 0.12))
 
 	assert.Equal(t, "Name: a, Value: 10, Percent: 12%",
-		labelFormatPie([]string{"a", "b"}, "Name: {b}, Value: {c}, Percent: {d}", nil,
-			0, 10, 0.12))
+		labelFormatPie("a", "Name: {b}, Value: {c}, Percent: {d}", nil, 10, 0.12))
+}
 
-	assert.Equal(t, "Name: b, Value: 20, Percent: 25%",
-		labelFormatPie([]string{"a", "b"}, "Name: {b}, Value: {c}, Percent: {d}", nil,
-			1, 20, 0.25))
+func TestSeriesLabelFormatter(t *testing.T) {
+	t.Parallel()
 
-	assert.Equal(t, "Empty Series '' 20",
-		labelFormatPie([]string{}, "Empty Series '{b}' {c}", nil,
-			1, 20, 0.25))
+	tests := []struct {
+		name     string
+		label    SeriesLabel
+		values   []labelValue
+		expected []string
+	}{
+		{
+			name: "label_formatter_with_index_based_highlighting",
+			label: SeriesLabel{
+				Show: Ptr(true),
+				LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+					if index == 1 { // highlight only second value
+						return "⭐ " + name + ": " + strconv.FormatFloat(val, 'f', 1, 64), nil
+					}
+					return "", nil // hide other labels
+				},
+			},
+			values: []labelValue{
+				{index: 0, value: 10.5},
+				{index: 1, value: 20.7},
+				{index: 2, value: 30.2},
+			},
+			expected: []string{"⭐ series1: 20.7"},
+		},
+		{
+			name: "label_formatter_returns_empty_string",
+			label: SeriesLabel{
+				Show: Ptr(true),
+				LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+					return "", nil // always return empty
+				},
+			},
+			values: []labelValue{
+				{index: 0, value: 10.5},
+			},
+			expected: []string{}, // should result in no rendered text
+		},
+		{
+			name: "label_formatter_with_custom_format",
+			label: SeriesLabel{
+				Show: Ptr(true),
+				LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+					return "Item " + strconv.Itoa(index) + ": $" + strconv.FormatFloat(val, 'f', 2, 64), nil
+				},
+			},
+			values: []labelValue{
+				{index: 0, value: 100.50},
+				{index: 1, value: 200.75},
+			},
+			expected: []string{"Item 0: $100.50", "Item 1: $200.75"},
+		},
+		{
+			name: "fallback_to_value_formatter_when_label_formatter_is_nil",
+			label: SeriesLabel{
+				Show: Ptr(true),
+				ValueFormatter: func(f float64) string {
+					return "Value: " + strconv.FormatFloat(f, 'f', 1, 64)
+				},
+			},
+			values: []labelValue{
+				{index: 0, value: 42.3},
+			},
+			expected: []string{"Value: 42.3"},
+		},
+		{
+			name: "fallback_to_format_template_when_label_formatter_is_nil",
+			label: SeriesLabel{
+				Show:           Ptr(true),
+				FormatTemplate: "Series {b} = {c}",
+			},
+			values: []labelValue{
+				{index: 0, value: 42.3},
+			},
+			expected: []string{"Series series0 = 42.3"},
+		},
+		{
+			name: "label_formatter_takes_precedence_over_format_template",
+			label: SeriesLabel{
+				Show:           Ptr(true),
+				FormatTemplate: "Template: {c}",
+				LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+					return "Formatter: " + strconv.FormatFloat(val, 'f', 0, 64), nil
+				},
+			},
+			values: []labelValue{
+				{index: 0, value: 42.3},
+			},
+			expected: []string{"Formatter: 42"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPainter(PainterOptions{
+				OutputFormat: ChartOutputSVG,
+				Width:        400,
+				Height:       300,
+			}, PainterThemeOption(GetTheme(ThemeLight)))
+
+			seriesNames := make([]string, len(tt.values))
+			for i := range seriesNames {
+				seriesNames[i] = "series" + strconv.Itoa(i)
+			}
+
+			painter := newSeriesLabelPainter(p, seriesNames, tt.label, GetTheme(ThemeLight))
+
+			// Add all values to the painter
+			for _, value := range tt.values {
+				painter.Add(value)
+			}
+
+			// Filter out empty text entries for comparison
+			var renderedText []string
+			for _, v := range painter.values {
+				if v.text != "" {
+					renderedText = append(renderedText, v.text)
+				}
+			}
+
+			// Handle empty slice vs nil slice case
+			if len(tt.expected) == 0 && len(renderedText) == 0 {
+				// Both empty, this is a pass
+			} else {
+				// Check that the correct text was generated
+				assert.Equal(t, tt.expected, renderedText)
+			}
+		})
+	}
+
+	t.Run("empty_series_names", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       300,
+		}, PainterThemeOption(GetTheme(ThemeLight)))
+
+		label := SeriesLabel{
+			Show: Ptr(true),
+			LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+				return "Index: " + strconv.Itoa(index) + ", Name: '" + name + "'", nil
+			},
+		}
+
+		painter := newSeriesLabelPainter(p, []string{}, label, GetTheme(ThemeLight))
+		painter.Add(labelValue{index: 0, value: 42.5})
+
+		// Should handle empty series names gracefully
+		assert.Len(t, painter.values, 1)
+		assert.Equal(t, "Index: 0, Name: ''", painter.values[0].text)
+	})
+
+	t.Run("out_of_bounds_series_index", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       300,
+		}, PainterThemeOption(GetTheme(ThemeLight)))
+
+		label := SeriesLabel{
+			Show: Ptr(true),
+			LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+				return "Index: " + strconv.Itoa(index) + ", Name: '" + name + "'", nil
+			},
+		}
+
+		painter := newSeriesLabelPainter(p, []string{"Series0"}, label, GetTheme(ThemeLight))
+		painter.Add(labelValue{index: 5, value: 42.5}) // Index beyond series names
+
+		// Should handle out of bounds gracefully with empty name
+		assert.Len(t, painter.values, 1)
+		assert.Equal(t, "Index: 5, Name: ''", painter.values[0].text)
+	})
+
+	t.Run("show_flag_false", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       300,
+		}, PainterThemeOption(GetTheme(ThemeLight)))
+
+		label := SeriesLabel{
+			Show: Ptr(false), // Explicitly hide labels
+			LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+				return "This should not appear", nil
+			},
+		}
+
+		painter := newSeriesLabelPainter(p, []string{"Test"}, label, GetTheme(ThemeLight))
+		painter.Add(labelValue{index: 0, value: 42.5})
+
+		// Should not add any values when Show is false
+		assert.Empty(t, painter.values)
+	})
+
+	t.Run("nil_label_formatter_fallback", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       300,
+		}, PainterThemeOption(GetTheme(ThemeLight)))
+
+		label := SeriesLabel{
+			Show: Ptr(true),
+			// No LabelFormatter, should fall back to defaultValueFormatter
+		}
+
+		painter := newSeriesLabelPainter(p, []string{"Test"}, label, GetTheme(ThemeLight))
+		painter.Add(labelValue{index: 0, value: 123.456})
+
+		// Should use defaultValueFormatter
+		assert.Len(t, painter.values, 1)
+		assert.Equal(t, "123.46", painter.values[0].text) // defaultValueFormatter truncates to 2 decimals
+	})
+}
+
+func TestDrawLabelWithBackground(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_text", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       400,
+		})
+
+		fontStyle := FontStyle{FontColor: ColorBlack, FontSize: 12}
+		drawLabelWithBackground(p, "", 50, 50, 0, fontStyle, ColorRed, 5, ColorTransparent, 0)
+
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assertEqualSVG(t, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 400\"></svg>", data)
+	})
+
+	t.Run("transparent_background", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       400,
+		})
+
+		fontStyle := FontStyle{FontColor: ColorBlack, FontSize: 12}
+		drawLabelWithBackground(p, "test", 50, 50, 0, fontStyle, ColorTransparent, 5, ColorTransparent, 0)
+
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assertEqualSVG(t, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 400\"><text x=\"50\" y=\"50\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">test</text></svg>", data)
+	})
+
+	t.Run("solid_background", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       400,
+		})
+
+		fontStyle := FontStyle{FontColor: ColorBlack, FontSize: 12}
+		drawLabelWithBackground(p, "test", 50, 50, 0, fontStyle, ColorBlue, 0, ColorTransparent, 0)
+
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assertEqualSVG(t, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 400\"><path  d=\"M 46 30\nL 81 30\nL 81 54\nL 46 54\nL 46 30\" style=\"stroke:none;fill:blue\"/><text x=\"50\" y=\"50\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">test</text></svg>", data)
+	})
+
+	t.Run("rounded_background", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       400,
+		})
+
+		fontStyle := FontStyle{FontColor: ColorBlack, FontSize: 12}
+		drawLabelWithBackground(p, "test", 50, 50, 0, fontStyle, ColorGreen, 5, ColorTransparent, 0)
+
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assertEqualSVG(t, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 400\"><path  d=\"M 51 30\nL 76 30\nL 76 30\nA 5 5 90.00 0 1 81 35\nL 81 49\nL 81 49\nA 5 5 90.00 0 1 76 54\nL 51 54\nL 51 54\nA 5 5 90.00 0 1 46 49\nL 46 35\nL 46 35\nA 5 5 90.00 0 1 51 30\nZ\" style=\"stroke:none;fill:green\"/><text x=\"50\" y=\"50\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">test</text></svg>", data)
+	})
+
+	t.Run("negative_corner_radius", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       400,
+		})
+
+		fontStyle := FontStyle{FontColor: ColorBlack, FontSize: 12}
+		// Negative corner radius should be treated as 0 (square corners)
+		drawLabelWithBackground(p, "test", 50, 50, 0, fontStyle, ColorRed, -5, ColorTransparent, 0)
+
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assertEqualSVG(t, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 400\"><path  d=\"M 46 30\nL 81 30\nL 81 54\nL 46 54\nL 46 30\" style=\"stroke:none;fill:red\"/><text x=\"50\" y=\"50\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">test</text></svg>", data)
+	})
+}
+
+func TestLabelStyleOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		label                   SeriesLabel
+		values                  []labelValue
+		expectedText            []string
+		expectedFontSize        []float64
+		expectedFontColor       []Color
+		expectedDistance        []int
+		expectedOffset          []OffsetInt
+		expectedBackgroundColor []Color
+		expectedCornerRadius    []int
+	}{
+		{
+			name: "nil_override_uses_base_styles",
+			label: SeriesLabel{
+				Show: Ptr(true),
+				LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+					return "base style", nil
+				},
+				FontStyle: FontStyle{FontSize: 12, FontColor: ColorRed},
+				Distance:  10,
+			},
+			values: []labelValue{
+				{index: 0, value: 10.5, offset: OffsetInt{Left: 1, Top: 2}},
+			},
+			expectedText:            []string{"base style"},
+			expectedFontSize:        []float64{12},
+			expectedFontColor:       []Color{ColorRed},
+			expectedDistance:        []int{10},
+			expectedOffset:          []OffsetInt{{Left: 1, Top: 2}},
+			expectedBackgroundColor: []Color{{}}, // Zero color value
+			expectedCornerRadius:    []int{0},
+		},
+		{
+			name: "override_some_fields",
+			label: SeriesLabel{
+				Show: Ptr(true),
+				LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+					return "style override", &LabelStyle{
+						FontStyle: FontStyle{FontSize: 16}, // only override size
+					}
+				},
+				FontStyle: FontStyle{FontSize: 12, FontColor: ColorRed},
+			},
+			values: []labelValue{
+				{index: 0, value: 10.5},
+			},
+			expectedText:            []string{"style override"},
+			expectedFontSize:        []float64{16},     // overridden
+			expectedFontColor:       []Color{ColorRed}, // from base
+			expectedBackgroundColor: []Color{{}},       // Zero color value
+			expectedCornerRadius:    []int{0},
+		},
+		{
+			name: "empty_text_hides_label",
+			label: SeriesLabel{
+				Show: Ptr(true),
+				LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+					return "", &LabelStyle{
+						FontStyle: FontStyle{FontSize: 20},
+					} // style ignored when text is empty
+				},
+			},
+			values: []labelValue{
+				{index: 0, value: 10.5},
+			},
+			expectedText:            []string{}, // no label rendered
+			expectedFontSize:        []float64{},
+			expectedFontColor:       []Color{},
+			expectedBackgroundColor: []Color{},
+			expectedCornerRadius:    []int{},
+		},
+		{
+			name: "per_point_color_changes",
+			label: SeriesLabel{
+				Show: Ptr(true),
+				LabelFormatter: func(index int, name string, val float64) (string, *LabelStyle) {
+					if index == 0 {
+						return "red", &LabelStyle{
+							FontStyle: FontStyle{FontColor: ColorRed},
+						}
+					}
+					return "blue", &LabelStyle{
+						FontStyle: FontStyle{FontColor: ColorBlue},
+					}
+				},
+			},
+			values: []labelValue{
+				{index: 0, value: 10.5},
+				{index: 1, value: 20.5},
+			},
+			expectedText:            []string{"red", "blue"},
+			expectedFontColor:       []Color{ColorRed, ColorBlue},
+			expectedBackgroundColor: []Color{{}, {}}, // Zero color values
+			expectedCornerRadius:    []int{0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPainter(PainterOptions{
+				OutputFormat: ChartOutputSVG,
+				Width:        800,
+				Height:       800,
+			}, PainterThemeOption(GetTheme(ThemeLight)))
+
+			seriesNames := make([]string, len(tt.values))
+			for i := range seriesNames {
+				seriesNames[i] = "series" + strconv.Itoa(i)
+			}
+
+			painter := newSeriesLabelPainter(p, seriesNames, tt.label, GetTheme(ThemeLight))
+
+			// Add all values to the painter
+			for _, value := range tt.values {
+				painter.Add(value)
+			}
+
+			// Filter out empty text entries for most checks (they shouldn't be rendered)
+			renderedValues := make([]labelRenderValue, 0, len(painter.values))
+			actualRenderedText := make([]string, 0, len(painter.values))
+			for _, v := range painter.values {
+				if v.text != "" {
+					renderedValues = append(renderedValues, v)
+					actualRenderedText = append(actualRenderedText, v.text)
+				}
+			}
+
+			// Check text (handle empty slice vs nil slice case)
+			if len(tt.expectedText) == 0 && len(actualRenderedText) == 0 {
+				// Both empty, this is a pass
+			} else {
+				assert.Equal(t, tt.expectedText, actualRenderedText)
+			}
+
+			// Check font size for rendered values
+			if len(tt.expectedFontSize) > 0 {
+				assert.Equal(t, len(tt.expectedFontSize), len(renderedValues))
+				for i, expected := range tt.expectedFontSize {
+					if i < len(renderedValues) {
+						assert.InDelta(t, expected, renderedValues[i].fontStyle.FontSize, matrix.DefaultEpsilon)
+					}
+				}
+			}
+
+			// Check font color for rendered values
+			if len(tt.expectedFontColor) > 0 {
+				assert.Equal(t, len(tt.expectedFontColor), len(renderedValues))
+				for i, expected := range tt.expectedFontColor {
+					if i < len(renderedValues) {
+						assert.Equal(t, expected, renderedValues[i].fontStyle.FontColor)
+					}
+				}
+			}
+
+			// Check background color for rendered values
+			if len(tt.expectedBackgroundColor) > 0 {
+				assert.Equal(t, len(tt.expectedBackgroundColor), len(renderedValues))
+				for i, expected := range tt.expectedBackgroundColor {
+					if i < len(renderedValues) {
+						assert.Equal(t, expected, renderedValues[i].backgroundColor)
+					}
+				}
+			}
+
+			// Check corner radius for rendered values
+			if len(tt.expectedCornerRadius) > 0 {
+				assert.Equal(t, len(tt.expectedCornerRadius), len(renderedValues))
+				for i, expected := range tt.expectedCornerRadius {
+					if i < len(renderedValues) {
+						assert.Equal(t, expected, renderedValues[i].cornerRadius)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestLabelFormatterThresholdMin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		threshold float64
+		testCases []struct {
+			value    float64
+			expected string
+		}
+	}{
+		{
+			name:      "threshold_100",
+			threshold: 100,
+			testCases: []struct {
+				value    float64
+				expected string
+			}{
+				{50, ""},
+				{100, "100"},
+				{150, "150"},
+				{200.5, "200.5"},
+			},
+		},
+		{
+			name:      "threshold_0",
+			threshold: 0,
+			testCases: []struct {
+				value    float64
+				expected string
+			}{
+				{-10, ""},
+				{0, "0"},
+				{0.1, "0.1"},
+				{50, "50"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := LabelFormatterThresholdMin(tt.threshold)
+
+			for _, tc := range tt.testCases {
+				text, style := formatter(0, "test", tc.value)
+				assert.Equal(t, tc.expected, text)
+				assert.Nil(t, style)
+			}
+		})
+	}
+
+	// Boundary conditions
+	t.Run("boundary_conditions", func(t *testing.T) {
+		t.Run("large_number", func(t *testing.T) {
+			formatter := LabelFormatterThresholdMin(1e6)
+
+			text, style := formatter(0, "test", 999999)
+			assert.Equal(t, "", text)
+			assert.Nil(t, style)
+
+			text, style = formatter(0, "test", 1000000)
+			assert.Equal(t, "1M", text) // defaultValueFormatter uses humanize for large numbers
+			assert.Nil(t, style)
+		})
+	})
+}
+
+func TestLabelFormatterThresholdMax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		threshold float64
+		testCases []struct {
+			value    float64
+			expected string
+		}
+	}{
+		{
+			name:      "threshold_100",
+			threshold: 100,
+			testCases: []struct {
+				value    float64
+				expected string
+			}{
+				{50, "50"},
+				{100, "100"},
+				{150, ""},
+				{200.5, ""},
+			},
+		},
+		{
+			name:      "threshold_0",
+			threshold: 0,
+			testCases: []struct {
+				value    float64
+				expected string
+			}{
+				{-10, "-10"},
+				{0, "0"},
+				{10, ""},
+				{100, ""},
+			},
+		},
+		{
+			name:      "threshold_negative",
+			threshold: -50,
+			testCases: []struct {
+				value    float64
+				expected string
+			}{
+				{-100, "-100"},
+				{-50, "-50"},
+				{-25, ""},
+				{0, ""},
+				{50, ""},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := LabelFormatterThresholdMax(tt.threshold)
+			for _, tc := range tt.testCases {
+				text, style := formatter(0, "", tc.value)
+				assert.Equal(t, tc.expected, text)
+				assert.Nil(t, style)
+			}
+		})
+	}
+}
+
+func TestLabelFormatterTopN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		values    []float64
+		n         int
+		testCases []struct {
+			index    int
+			value    float64
+			expected string
+		}
+	}{
+		{
+			name:   "top_2_of_5",
+			values: []float64{100, 200, 50, 300, 75},
+			n:      2,
+			testCases: []struct {
+				index    int
+				value    float64
+				expected string
+			}{
+				{0, 100, ""},
+				{1, 200, "200"}, // 2nd highest
+				{2, 50, ""},
+				{3, 300, "300"}, // highest
+				{4, 75, ""},
+			},
+		},
+		{
+			name:   "top_1_of_3",
+			values: []float64{10, 30, 20},
+			n:      1,
+			testCases: []struct {
+				index    int
+				value    float64
+				expected string
+			}{
+				{0, 10, ""},
+				{1, 30, "30"}, // highest
+				{2, 20, ""},
+			},
+		},
+		{
+			name:   "top_5_of_3_all_shown",
+			values: []float64{10, 30, 20},
+			n:      5,
+			testCases: []struct {
+				index    int
+				value    float64
+				expected string
+			}{
+				{0, 10, "10"}, // all shown when n > series length
+				{1, 30, "30"},
+				{2, 20, "20"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := LabelFormatterTopN(tt.values, tt.n)
+
+			for _, tc := range tt.testCases {
+				text, style := formatter(tc.index, "test", tc.value)
+				assert.Equal(t, tc.expected, text)
+				assert.Nil(t, style)
+			}
+		})
+	}
+
+	edgeTests := []struct {
+		name          string
+		values        []float64
+		n             int
+		testValue     float64
+		expectedText  string
+		shouldShowAll bool // whether it should behave like LabelFormatterValueShort
+	}{
+		{"negative_n", []float64{10, 20, 30}, -1, 20.0, "", false},
+		{"zero_n", []float64{10, 20, 30}, 0, 20.0, "", false},
+		{"n_greater_than_length", []float64{10, 20}, 5, 20.0, "20", true},
+		{"n_equal_to_length", []float64{10, 20}, 2, 20, "20", true},
+		{"single_value", []float64{42}, 1, 42.0, "42", true},
+	}
+
+	for _, tt := range edgeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := LabelFormatterTopN(tt.values, tt.n)
+
+			text, style := formatter(0, "test label", tt.testValue)
+
+			assert.Equal(t, tt.expectedText, text)
+			assert.Nil(t, style) // TopN doesn't add style, only controls visibility
+		})
+	}
+}
+
+func TestLabelFormatterGradientGreenRed(t *testing.T) {
+	t.Parallel()
+
+	values := []float64{10, 30, 20}
+
+	formatter := LabelFormatterGradientGreenRed(values)
+
+	tests := []struct {
+		name          string
+		value         float64
+		expected      string
+		expectedColor Color
+	}{
+		{"min_value", 10, "10", ColorGreen},      // minimum gets green
+		{"mid_value", 20, "20", ColorYellowAlt1}, // middle gets yellowalt1
+		{"max_value", 30, "30", ColorRed},        // maximum gets red
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, style := formatter(0, "test series label", tt.value)
+			assert.Equal(t, tt.expected, text)
+			assert.NotNil(t, style)
+			assert.Equal(t, tt.expectedColor, style.FontStyle.FontColor)
+		})
+	}
+}
+
+func TestLabelFormatterGradientRedGreen(t *testing.T) {
+	t.Parallel()
+
+	values := []float64{10, 30, 20}
+
+	formatter := LabelFormatterGradientRedGreen(values)
+
+	tests := []struct {
+		name          string
+		value         float64
+		expected      string
+		expectedColor Color
+	}{
+		{"min_value", 10, "10", ColorRed},        // minimum gets red
+		{"mid_value", 20, "20", ColorYellowAlt1}, // middle gets yellowalt1
+		{"max_value", 30, "30", ColorGreen},      // maximum gets green
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, style := formatter(0, "test series label", tt.value)
+			assert.Equal(t, tt.expected, text)
+			assert.NotNil(t, style)
+			assert.Equal(t, tt.expectedColor, style.FontStyle.FontColor)
+		})
+	}
+}
+
+func TestLabelFormatterGradientColor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		values    []float64
+		colors    []Color
+		testCases []struct {
+			value         float64
+			expectedText  string
+			expectedColor Color
+		}
+	}{
+		{
+			name:   "blue_to_red_gradient_two_colors",
+			values: []float64{0, 50, 100},
+			colors: []Color{ColorBlue, ColorRed},
+			testCases: []struct {
+				value         float64
+				expectedText  string
+				expectedColor Color
+			}{
+				{0, "0", ColorBlue},    // minimum gets low color
+				{100, "100", ColorRed}, // maximum gets high color
+			},
+		},
+		{
+			name:   "green_yellow_red_gradient_three_colors",
+			values: []float64{10, 20, 30},
+			colors: []Color{ColorGreen, ColorYellowAlt1, ColorRed},
+			testCases: []struct {
+				value         float64
+				expectedText  string
+				expectedColor Color
+			}{
+				{10, "10", ColorGreen},      // minimum gets green
+				{20, "20", ColorYellowAlt1}, // middle gets yellowalt1
+				{30, "30", ColorRed},        // maximum gets red
+			},
+		},
+		{
+			name:   "same_values_all_first_color",
+			values: []float64{50, 50, 50},
+			colors: []Color{ColorGreen, ColorYellowAlt1},
+			testCases: []struct {
+				value         float64
+				expectedText  string
+				expectedColor Color
+			}{
+				{50, "50", ColorGreen}, // all same values get first color
+			},
+		},
+		{
+			name:   "single_color",
+			values: []float64{10, 20, 30},
+			colors: []Color{ColorBlue},
+			testCases: []struct {
+				value         float64
+				expectedText  string
+				expectedColor Color
+			}{
+				{10, "10", ColorBlue}, // all values get the single color
+				{20, "20", ColorBlue},
+				{30, "30", ColorBlue},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := LabelFormatterGradientColor(tt.values, tt.colors...)
+
+			for _, tc := range tt.testCases {
+				text, style := formatter(0, "test", tc.value)
+				assert.Equal(t, tc.expectedText, text)
+				assert.NotNil(t, style)
+				assert.Equal(t, tc.expectedColor, style.FontStyle.FontColor)
+			}
+		})
+	}
+
+	edgeTests := []struct {
+		name            string
+		values          []float64
+		colors          []Color
+		testValue       float64
+		expectedText    string
+		expectedColor   Color
+		shouldHaveStyle bool
+	}{
+		{
+			name:            "empty_values",
+			values:          []float64{},
+			colors:          []Color{ColorRed, ColorBlue},
+			testValue:       50,
+			expectedText:    "50",
+			expectedColor:   ColorRed, // should default to first color
+			shouldHaveStyle: true,
+		},
+		{
+			name:            "no_colors",
+			values:          []float64{10, 20, 30},
+			colors:          []Color{},
+			testValue:       20,
+			expectedText:    "20",
+			expectedColor:   ColorBlack, // fallback to black
+			shouldHaveStyle: true,
+		},
+		{
+			name:            "nil_values",
+			values:          nil,
+			colors:          []Color{ColorGreen},
+			testValue:       100,
+			expectedText:    "100",
+			expectedColor:   ColorGreen,
+			shouldHaveStyle: true,
+		},
+		{
+			name:            "single_value",
+			values:          []float64{42},
+			colors:          []Color{ColorYellow, ColorRed},
+			testValue:       42,
+			expectedText:    "42",
+			expectedColor:   ColorYellow, // all same values get first color
+			shouldHaveStyle: true,
+		},
+	}
+
+	for _, tt := range edgeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := LabelFormatterGradientColor(tt.values, tt.colors...)
+			text, style := formatter(0, "test", tt.testValue)
+
+			assert.Equal(t, tt.expectedText, text)
+			if tt.shouldHaveStyle {
+				assert.NotNil(t, style)
+				assert.Equal(t, tt.expectedColor, style.FontStyle.FontColor)
+			} else {
+				assert.Nil(t, style)
+			}
+		})
+	}
+}
+
+func TestLabelFormatterValueShort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    float64
+		expected string
+	}{
+		{"integer", 100, "100"},
+		{"decimal", 123.45, "123.45"},
+		{"small_decimal", 0.123, "0.12"},
+		{"zero", 0, "0"},
+		{"negative", -50.67, "-50.67"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, style := LabelFormatterValueShort(0, "test", tt.value)
+			assert.Equal(t, tt.expected, text)
+			assert.Nil(t, style)
+		})
+	}
+}
+
+func TestLabelFormatterNameShortValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		seriesName string
+		value      float64
+		expected   string
+	}{
+		{"basic", "Sales", 100, "Sales: 100"},
+		{"with_decimal", "Revenue", 123.45, "Revenue: 123.45"},
+		{"empty_name", "", 50, ": 50"},
+		{"special_chars", "Q1-Sales", 999.99, "Q1-Sales: 999.99"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, style := LabelFormatterNameShortValue(0, tt.seriesName, tt.value)
+			assert.Equal(t, tt.expected, text)
+			assert.Nil(t, style)
+		})
+	}
+}
+
+func TestInterpolateMultipleColors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		colors   []Color
+		factor   float64
+		expected Color
+	}{
+		{
+			name:     "no_colors_fallback",
+			colors:   []Color{},
+			factor:   0.5,
+			expected: ColorBlack,
+		},
+		{
+			name:     "single_color",
+			colors:   []Color{ColorBlue},
+			factor:   0.5,
+			expected: ColorBlue,
+		},
+		{
+			name:     "two_colors_start",
+			colors:   []Color{ColorRed, ColorBlue},
+			factor:   0.0,
+			expected: ColorRed,
+		},
+		{
+			name:     "two_colors_end",
+			colors:   []Color{ColorRed, ColorBlue},
+			factor:   1.0,
+			expected: ColorBlue,
+		},
+		{
+			name:     "three_colors_start",
+			colors:   []Color{ColorGreen, ColorYellow, ColorRed},
+			factor:   0.0,
+			expected: ColorGreen,
+		},
+		{
+			name:     "three_colors_middle",
+			colors:   []Color{ColorGreen, ColorYellow, ColorRed},
+			factor:   0.5,
+			expected: ColorYellow,
+		},
+		{
+			name:     "three_colors_end",
+			colors:   []Color{ColorGreen, ColorYellow, ColorRed},
+			factor:   1.0,
+			expected: ColorRed,
+		},
+		{
+			name:     "factor_beyond_range",
+			colors:   []Color{ColorGreen, ColorRed},
+			factor:   1.5,
+			expected: ColorRed, // should clamp to end
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := interpolateMultipleColors(tt.colors, tt.factor)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestInterpolateColor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		color1   Color
+		color2   Color
+		factor   float64
+		expected Color
+	}{
+		{
+			name:     "factor_negative",
+			color1:   ColorRed,
+			color2:   ColorBlue,
+			factor:   -0.5,
+			expected: ColorRed, // Should clamp to start color
+		},
+		{
+			name:     "factor_greater_than_one",
+			color1:   ColorRed,
+			color2:   ColorBlue,
+			factor:   1.5,
+			expected: ColorBlue, // Should clamp to end color
+		},
+		{
+			name:     "factor_exactly_zero",
+			color1:   ColorGreen,
+			color2:   ColorYellow,
+			factor:   0.0,
+			expected: ColorGreen,
+		},
+		{
+			name:     "factor_exactly_one",
+			color1:   ColorGreen,
+			color2:   ColorYellow,
+			factor:   1.0,
+			expected: ColorYellow,
+		},
+		{
+			name:     "same_colors",
+			color1:   ColorBlue,
+			color2:   ColorBlue,
+			factor:   0.5,
+			expected: ColorBlue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := interpolateColor(tt.color1, tt.color2, tt.factor)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDrawLabelWithBackgroundBorders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("border_with_background", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       400,
+		})
+
+		fontStyle := FontStyle{FontColor: ColorBlack, FontSize: 12}
+		drawLabelWithBackground(p, "test", 50, 50, 0, fontStyle, ColorBlue, 0, ColorRed, 2)
+
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assertEqualSVG(t, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 400\"><path  d=\"M 46 30\nL 81 30\nL 81 54\nL 46 54\nL 46 30\" style=\"stroke-width:2;stroke:red;fill:blue\"/><text x=\"50\" y=\"50\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">test</text></svg>", data)
+	})
+
+	t.Run("border_without_background", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       400,
+		})
+
+		fontStyle := FontStyle{FontColor: ColorBlack, FontSize: 12}
+		drawLabelWithBackground(p, "test", 50, 50, 0, fontStyle, ColorTransparent, 0, ColorGreen, 1.5)
+
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assertEqualSVG(t, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 400\"><path  d=\"M 46 30\nL 81 30\nL 81 54\nL 46 54\nL 46 30\" style=\"stroke-width:1.5;stroke:green;fill:none\"/><text x=\"50\" y=\"50\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">test</text></svg>", data)
+	})
+
+	t.Run("no_border_no_background", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       400,
+		})
+
+		fontStyle := FontStyle{FontColor: ColorBlack, FontSize: 12}
+		drawLabelWithBackground(p, "test", 50, 50, 0, fontStyle, ColorTransparent, 0, ColorTransparent, 0)
+
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assertEqualSVG(t, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 400\"><text x=\"50\" y=\"50\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">test</text></svg>", data)
+	})
+
+	t.Run("rounded_corners_with_border", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        400,
+			Height:       400,
+		})
+
+		fontStyle := FontStyle{FontColor: ColorBlack, FontSize: 12}
+		drawLabelWithBackground(p, "test", 50, 50, 0, fontStyle, ColorYellow, 8, ColorBlue, 3)
+
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assertEqualSVG(t, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 400 400\"><path  d=\"M 54 30\nL 73 30\nL 73 30\nA 8 8 90.00 0 1 81 38\nL 81 46\nL 81 46\nA 8 8 90.00 0 1 73 54\nL 54 54\nL 54 54\nA 8 8 90.00 0 1 46 46\nL 46 38\nL 46 38\nA 8 8 90.00 0 1 54 30\nZ\" style=\"stroke-width:3;stroke:blue;fill:yellow\"/><text x=\"50\" y=\"50\" style=\"stroke:none;fill:black;font-size:15.3px;font-family:'Roboto Medium',sans-serif\">test</text></svg>", data)
+	})
 }

--- a/theme.go
+++ b/theme.go
@@ -61,13 +61,13 @@ type ColorPalette interface {
 	GetYAxisTextColor() Color
 	GetTitleBorderColor() Color
 	GetLegendBorderColor() Color
-	// WithXAxisColor returns a new ColorPalette with the specified X-axis color.
+	// WithXAxisColor returns a new ColorPalette with the specified x-axis color.
 	// Use WithXAxisTextColor to adjust the text color.
 	WithXAxisColor(Color) ColorPalette
-	// WithYAxisColor returns a new ColorPalette with the specified Y-axis color.
+	// WithYAxisColor returns a new ColorPalette with the specified y-axis color.
 	// Use WithYAxisTextColor to adjust the text color.
 	WithYAxisColor(Color) ColorPalette
-	// WithYAxisSeriesColor returns a new ColorPalette using the specified series color for Y-axis and values.
+	// WithYAxisSeriesColor returns a new ColorPalette using the specified series color for y-axis and values.
 	WithYAxisSeriesColor(int) ColorPalette
 	// WithTitleTextColor returns a new ColorPalette with the specified title text color.
 	WithTitleTextColor(Color) ColorPalette

--- a/xaxis.go
+++ b/xaxis.go
@@ -21,7 +21,7 @@ type XAxisOption struct {
 	// Deprecated: Position is deprecated. Currently, when set to `bottom` and the labels would render on the top
 	// side of the axis line. However, the line would remain at the bottom of the chart. This seems confusing, and
 	// attempts to actually move the axis line to the top of the chart are currently very messy looking. For that
-	// reason this is currently deprecated. If a top X-Axis is valuable to you, please open a feature request.
+	// reason this is currently deprecated. If a top x-Axis is valuable to you, please open a feature request.
 	Position string
 	// BoundaryGap specifies that the chart should have additional space on the left and right, with data points being
 	// centered between two axis ticks. Default is set based on the dataset density / size to produce an easy-to-read

--- a/yaxis.go
+++ b/yaxis.go
@@ -10,7 +10,7 @@ type YAxisOption struct {
 	Show *bool
 	// Theme specifies the colors used for the y-axis.
 	Theme ColorPalette
-	// Title specifies a name for the axis. If set, the axis name is rendered on the outside of the Y-Axis.
+	// Title specifies a name for the axis. If set, the axis name is rendered on the outside of the y-Axis.
 	Title string
 	// TitleFontStyle specifies the font, size, and color for the axis title.
 	TitleFontStyle FontStyle


### PR DESCRIPTION
Prior to this change all data labels had to be enabled or disabled, as well as with a matching style. This left mark points to be the only way to highlight specific values.

With this change a `SeriesLabelFormatter` can now be set on the `SeriesLabel` struct. This function allows for selective hidding of values (by returning an empty string), as well as selective changes to the text style or a background behind the label.

This is designed for emphasizing specific values, and with that `LabelFormatterThresholdMin`, `LabelFormatterTopN`, `LabelFormatterProgressiveGreenRed`, and `LabelFormatterProgressiveColor` were added as helpers to easily highlight upper values.

`SeriesLabel.FormatTemplate` has been deprecated to be removed in `v0.6.0`.  The new `LabelFormatter` function is a more powerful alternative.