### PR TITLE
add simple script to generate gallery of examples for chartdraw (wcharczuk/go-chart)

### DIFF
--- a/chartdraw/examples/_examples_gallery.md
+++ b/chartdraw/examples/_examples_gallery.md
@@ -1,0 +1,162 @@
+# Examples gallery
+<p>
+
+## [annotations](annotations)
+
+![annotations](annotations/output.png)
+<p>
+
+## [axes](axes)
+
+![axes](axes/output.png)
+<p>
+
+## [axes_labels](axes_labels)
+
+![axes_labels](axes_labels/output.png)
+<p>
+
+## [bar_chart](bar_chart)
+
+![bar_chart](bar_chart/output.png)
+<p>
+
+## [bar_chart_base_value](bar_chart_base_value)
+
+![bar_chart_base_value](bar_chart_base_value/output.png)
+<p>
+
+## [basic](basic)
+
+![basic](basic/output.png)
+<p>
+
+## [benchmark_line_charts](benchmark_line_charts)
+
+![benchmark_line_charts](benchmark_line_charts/output.png)
+<p>
+
+## [custom_formatters](custom_formatters)
+
+![custom_formatters](custom_formatters/output.png)
+<p>
+
+## [custom_padding](custom_padding)
+
+![custom_padding](custom_padding/output.png)
+<p>
+
+## [custom_ranges](custom_ranges)
+
+![custom_ranges](custom_ranges/output.png)
+<p>
+
+## [custom_styles](custom_styles)
+
+![custom_styles](custom_styles/output.png)
+<p>
+
+## [custom_ticks](custom_ticks)
+
+![custom_ticks](custom_ticks/output.png)
+<p>
+
+## [descending](descending)
+
+![descending](descending/output.png)
+<p>
+
+## [donut_chart](donut_chart)
+
+![donut_chart](donut_chart/output.png)
+<p>
+
+## [horizontal_stacked_bar](horizontal_stacked_bar)
+
+![horizontal_stacked_bar](horizontal_stacked_bar/output.png)
+<p>
+
+## [legend](legend)
+
+![legend](legend/output.png)
+<p>
+
+## [legend_left](legend_left)
+
+![legend_left](legend_left/output.png)
+<p>
+
+## [linear_regression](linear_regression)
+
+![linear_regression](linear_regression/output.png)
+<p>
+
+## [logarithmic_axes](logarithmic_axes)
+
+![logarithmic_axes](logarithmic_axes/output.png)
+<p>
+
+## [min_max](min_max)
+
+![min_max](min_max/output.png)
+<p>
+
+## [pie_chart](pie_chart)
+
+![pie_chart](pie_chart/output.png)
+<p>
+
+## [poly_regression](poly_regression)
+
+![poly_regression](poly_regression/output.png)
+<p>
+
+## [request_timings](request_timings)
+
+![request_timings](request_timings/output.png)
+<p>
+
+## [scatter](scatter)
+
+![scatter](scatter/output.png)
+<p>
+
+## [simple_moving_average](simple_moving_average)
+
+![simple_moving_average](simple_moving_average/output.png)
+<p>
+
+## [stacked_bar](stacked_bar)
+
+![stacked_bar](stacked_bar/output.png)
+<p>
+
+## [stacked_bar_labels](stacked_bar_labels)
+
+![stacked_bar_labels](stacked_bar_labels/output.png)
+<p>
+
+## [stock_analysis](stock_analysis)
+
+![stock_analysis](stock_analysis/output.png)
+<p>
+
+## [text_rotation](text_rotation)
+
+![text_rotation](text_rotation/output.png)
+<p>
+
+## [timeseries](timeseries)
+
+![timeseries](timeseries/output.png)
+<p>
+
+## [twoaxis](twoaxis)
+
+![twoaxis](twoaxis/output.png)
+<p>
+
+## [twopoint](twopoint)
+
+![twopoint](twopoint/output.png)
+<p>

--- a/chartdraw/examples/make_examples_gallery.go
+++ b/chartdraw/examples/make_examples_gallery.go
@@ -1,0 +1,65 @@
+// Basic script to create file _examples_gallery.md
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const gallerymd = "_examples_gallery.md"
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	abs, err := filepath.Abs(".")
+	if err != nil {
+		return err
+	}
+	cwd := filepath.Base(abs)
+	if cwd != "examples" {
+		return fmt.Errorf("you must be in the charts/chartdraw/examples directory")
+	}
+	gallery, err := os.Create(gallerymd)
+	if err != nil {
+		return err
+	}
+	defer gallery.Close()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		return err
+	}
+	type example struct {
+		dirName   string
+		imagePath string
+	}
+	var examples []example
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		imagePath := filepath.Join(entry.Name(), "output.png")
+		_, err := os.Stat(imagePath)
+		if err != nil {
+			fmt.Printf("%-70s continuing\n", err)
+			continue
+		}
+		examples = append(examples, example{dirName: entry.Name(), imagePath: imagePath})
+	}
+
+	fmt.Fprintf(gallery, "# Examples gallery\n<p>\n")
+	for _, example := range examples {
+		fmt.Fprintf(gallery, "\n## [%s](%s)\n", example.dirName, example.dirName)
+		fmt.Fprintf(gallery, "\n![%s](%s)\n<p>\n", example.dirName, example.imagePath)
+	}
+
+	fmt.Printf("\nUpdated file %s; remember to commit\n", gallerymd)
+	return nil
+}


### PR DESCRIPTION
Hello,

I wanted an overview of what was possible with package `chartdraw`.
If I am not mistaken, the wiki has only examples for package `charts`. This is why I created this script. To me, it has the advantage of not only being generated automatically, but also to be more discoverable than the wiki.

To see the rendered markdown file, go to the github page for the branch: [github.com/marco-m/go-analyze-charts/blob/chartdraw-gallery/chartdraw/examples/_examples_gallery.md](https://github.com/marco-m/go-analyze-charts/blob/chartdraw-gallery/chartdraw/examples/_examples_gallery.md)

Thanks for maintaining and enhancing these two packages!