### PR TITLE
feat: Support negative / bi-directional Bar Charts

### DIFF
--- a/bar_chart.go
+++ b/bar_chart.go
@@ -206,8 +206,9 @@ func (b *barChart) renderVerticalBars(result *defaultRenderResult) (Box, error) 
 	stackedSeries := flagIs(true, opt.StackSeries)
 	barSize := opt.BarSize
 	var margin, barMargin, barWidth int
-	var accumulatedHeights []int // prior heights for stacking to avoid recalculating the heights
-	var barLanes []int           // bar lane per series when stacked
+	// diverging stacks: positive values accumulate above the baseline, negative values below
+	var accumulatedPos, accumulatedNeg []int // signed pixel offsets from the baseline
+	var barLanes []int                       // bar lane per series when stacked
 	if stackedSeries {
 		var barCount int
 		barLanes, barCount = stackedBarLanes(opt.SeriesList)
@@ -217,7 +218,8 @@ func (b *barChart) renderVerticalBars(result *defaultRenderResult) (Box, error) 
 		}
 		margin, barMargin, barWidth = calculateGroupMarginsAndSize(barCount, width,
 			resolveBarSizePixels(barSize, width, barCount), resolveBarMarginPixels(configuredMargin, width))
-		accumulatedHeights = make([]int, result.categoryAxisRange.divideCount)
+		accumulatedPos = make([]int, result.categoryAxisRange.divideCount)
+		accumulatedNeg = make([]int, result.categoryAxisRange.divideCount)
 	} else {
 		margin, barMargin, barWidth = calculateGroupMarginsAndSize(seriesCount, width,
 			resolveBarSizePixels(barSize, width, seriesCount), resolveBarMarginPixels(opt.BarMargin, width))
@@ -238,6 +240,8 @@ func (b *barChart) renderVerticalBars(result *defaultRenderResult) (Box, error) 
 			lane = barLanes[index]
 		}
 		yRange := result.valueAxisRanges[series.YAxisIndex]
+		baselineValue := max(min(0.0, yRange.max), yRange.min) // bars extend from zero, clamped to the axis range
+		basePx := yRange.getRestHeight(baselineValue)
 		seriesThemeIndex := index
 		if series.absThemeIndex != nil {
 			seriesThemeIndex = *series.absThemeIndex
@@ -251,6 +255,10 @@ func (b *barChart) renderVerticalBars(result *defaultRenderResult) (Box, error) 
 		}
 
 		points := make([]Point, len(series.Values)) // used for mark points
+		var pointRotations []float64
+		if len(series.MarkPoint.Points) > 0 {
+			pointRotations = make([]float64, len(series.Values))
+		}
 		for j, item := range series.Values {
 			if j >= result.categoryAxisRange.divideCount {
 				break
@@ -260,36 +268,60 @@ func (b *barChart) renderVerticalBars(result *defaultRenderResult) (Box, error) 
 
 			// Compute bar placement differently for stacked vs non-stacked.
 			var top, bottom int
-			h := yRange.getHeight(item)
+			var negativeBar bool // bar extends below the baseline
 			x := divideValues[j] + margin + lane*(barWidth+barMargin)
 
 			if stackSeries {
-				// Use accumulatedHeights to stack
-				top = barMaxHeight - (accumulatedHeights[j] + h)
-				bottom = barMaxHeight - accumulatedHeights[j]
-				accumulatedHeights[j] += h
+				negativeBar = item < 0
+				acc := accumulatedPos
+				if negativeBar {
+					acc = accumulatedNeg
+				}
+				h := yRange.getHeightDelta(item)
+				top = basePx - (acc[j] + h)
+				bottom = basePx - acc[j]
+				acc[j] += h
+				if top > bottom {
+					top, bottom = bottom, top
+				}
 			} else {
-				top = barMaxHeight - h
-				bottom = barMaxHeight - 1 // or -0, depending on your style
+				tipY := yRange.getRestHeight(item)
+				negativeBar = item < baselineValue
+				if negativeBar {
+					top, bottom = basePx+1, tipY
+				} else {
+					top, bottom = tipY, basePx-1
+				}
 			}
 
 			// In stacked mode, only round caps on the last stacked series
 			if flagIs(true, opt.RoundedBarCaps) && (!stackSeries || index == lastStackedIndex) {
+				corners := roundTopLeft | roundTopRight
+				if negativeBar {
+					corners = roundBottomLeft | roundBottomRight
+				}
 				seriesPainter.roundedRect(
 					Box{Top: top, Left: x, Right: x + barWidth, Bottom: bottom, IsSet: true},
-					barWidth, roundTopLeft|roundTopRight, seriesColor, seriesColor, 0.0)
+					barWidth, corners, seriesColor, seriesColor, 0.0)
 			} else {
 				seriesPainter.FilledRect(x, top, x+barWidth, bottom, seriesColor, seriesColor, 0.0)
 			}
 
+			tip := top
+			if negativeBar {
+				tip = bottom
+			}
 			// Prepare point for mark points
 			points[j] = Point{
 				X: x + (barWidth >> 1), // center of the bar horizontally
-				Y: top,                 // top of bar
+				Y: tip,                 // value end of bar
+			}
+			if pointRotations != nil && negativeBar {
+				pointRotations[j] = math.Pi // flip pin below the bar
 			}
 
 			if labelPainter != nil {
-				labelY := top
+				labelY := tip
 				var radians float64
 				fontStyle := series.Label.FontStyle
 				labelBottom := opt.SeriesLabelPosition == PositionBottom && !stackSeries
@@ -316,6 +348,7 @@ func (b *barChart) renderVerticalBars(result *defaultRenderResult) (Box, error) 
 				}
 				labelPainter.Add(labelValue{
 					vertical:  true, // label is vertically oriented
+					flipped:   negativeBar && !labelBottom,
 					index:     index,
 					dataIndex: j,
 					value:     item,
@@ -381,6 +414,7 @@ func (b *barChart) renderVerticalBars(result *defaultRenderResult) (Box, error) 
 					fillColor:          seriesColor,
 					font:               series.Label.FontStyle.Font,
 					symbolSize:         series.MarkPoint.SymbolSize,
+					pointRotations:     pointRotations,
 					markpoints:         seriesMarks,
 					seriesValues:       series.Values,
 					points:             points,
@@ -392,19 +426,26 @@ func (b *barChart) renderVerticalBars(result *defaultRenderResult) (Box, error) 
 				if globalSeriesData == nil {
 					globalSeriesData = sumSeriesData(opt.SeriesList, series.YAxisIndex)
 				}
-				// global marks anchor to the top of the combined stack, not this series' points
-				globalPoints := make([]Point, len(accumulatedHeights))
-				for j := range accumulatedHeights {
+				// global marks anchor to the stack's outer edge on the side of the net sum
+				globalPoints := make([]Point, len(accumulatedPos))
+				globalRotations := make([]float64, len(accumulatedPos))
+				for j := range accumulatedPos {
 					x := divideValues[j] + margin + lane*(barWidth+barMargin)
+					edge := accumulatedPos[j]
+					if accumulatedPos[j]+accumulatedNeg[j] < 0 {
+						edge = accumulatedNeg[j]
+						globalRotations[j] = math.Pi // flip pin below the stack
+					}
 					globalPoints[j] = Point{
 						X: x + (barWidth >> 1),
-						Y: barMaxHeight - accumulatedHeights[j],
+						Y: basePx - edge,
 					}
 				}
 				markPointPainter.add(markPointRenderOption{
 					fillColor:          defaultGlobalMarkFillColor,
 					font:               series.Label.FontStyle.Font,
 					symbolSize:         series.MarkPoint.SymbolSize,
+					pointRotations:     globalRotations,
 					markpoints:         globalMarks,
 					seriesValues:       globalSeriesData,
 					points:             globalPoints,
@@ -471,20 +512,24 @@ func (b *barChart) renderHorizontalBars(result *defaultRenderResult) (Box, error
 	height := int(y1 - y0)
 	stackedSeries := flagIs(true, opt.StackSeries)
 	// TODO - propagate per-axis reversed flag once horizontal bars support multiple value axes
-	reversed := result.valueAxisRanges[0].reversed // bars grow from the right when the category axis is on the right
-	plotWidth := seriesPainter.Width()
-	// baselineX is the value=0 edge; dir is the direction bars grow.
-	baselineX, dir := 0, 1
+	xRange := result.valueAxisRanges[0]
+	reversed := xRange.reversed // bars grow from the right when the category axis is on the right
+	// baselineX is the pixel of the zero value, clamped to the axis range; dir is the direction bars grow.
+	baselineValue := max(min(0.0, xRange.max), xRange.min)
+	baselineX := xRange.valuePosition(baselineValue)
+	dir := 1
 	if reversed {
-		baselineX, dir = plotWidth, -1
+		dir = -1
 	}
 	barSize := opt.BarSize
 
-	// if stacking, keep track of accumulated widths for each data index (after the "reverse" logic)
-	var accumulatedWidths []int
+	// if stacking, keep track of accumulated widths for each data index (after the "reverse" logic).
+	// diverging stacks: positive values accumulate past the baseline, negative values behind it
+	var accumulatedPos, accumulatedNeg []int // signed pixel offsets from the baseline
 	var margin, barMargin, barHeight int
 	if stackedSeries {
-		accumulatedWidths = make([]int, yRange.divideCount)
+		accumulatedPos = make([]int, yRange.divideCount)
+		accumulatedNeg = make([]int, yRange.divideCount)
 		margin, _, barHeight = calculateGroupMarginsAndSize(1, height,
 			resolveBarSizePixels(barSize, height, 1), nil)
 	} else {
@@ -514,6 +559,10 @@ func (b *barChart) renderHorizontalBars(result *defaultRenderResult) (Box, error
 		}
 
 		points := make([]Point, len(series.Values))
+		var pointRotations []float64
+		if len(series.MarkPoint.Points) > 0 {
+			pointRotations = make([]float64, len(series.Values))
+		}
 		for j, item := range series.Values {
 			if j >= yRange.divideCount {
 				break
@@ -526,22 +575,28 @@ func (b *barChart) renderHorizontalBars(result *defaultRenderResult) (Box, error
 			// Compute the top of this bar "row"
 			y := divideValues[reversedJ] + margin
 
-			// Determine the width (horizontal length) of the bar based on the data value
-			w := result.valueAxisRanges[0].getHeight(item)
-
 			// stackBase is the bar's category-axis-side edge; tipX is the value-end edge.
 			var stackBase, tipX int
+			var negativeBar bool // bar extends below the baseline
 			if stackedSeries {
-				stackBase = baselineX + dir*accumulatedWidths[reversedJ]
-				accumulatedWidths[reversedJ] += w
+				negativeBar = item < 0
+				acc := accumulatedPos
+				if negativeBar {
+					acc = accumulatedNeg
+				}
+				w := xRange.getHeightDelta(item)
+				stackBase = baselineX + dir*acc[reversedJ]
+				acc[reversedJ] += w
+				tipX = stackBase + dir*w
 			} else {
 				// Offset each series in its own lane
 				if index != 0 {
 					y += index * (barHeight + barMargin)
 				}
 				stackBase = baselineX
+				tipX = xRange.valuePosition(item)
+				negativeBar = item < baselineValue
 			}
-			tipX = stackBase + dir*w
 			left, right := stackBase, tipX
 			if left > right {
 				left, right = right, left
@@ -549,7 +604,7 @@ func (b *barChart) renderHorizontalBars(result *defaultRenderResult) (Box, error
 
 			// In stacked mode, only round caps on the last series
 			roundedCorners := roundTopRight | roundBottomRight
-			if reversed {
+			if negativeBar != reversed { // rounded cap on the direction the bar grows
 				roundedCorners = roundTopLeft | roundBottomLeft
 			}
 			if flagIs(true, opt.RoundedBarCaps) && (!stackedSeries || index == seriesCount-1) {
@@ -564,6 +619,14 @@ func (b *barChart) renderHorizontalBars(result *defaultRenderResult) (Box, error
 			points[j] = Point{
 				X: tipX,
 				Y: y + (barHeight >> 1), // vertical center of bar
+			}
+			if pointRotations != nil {
+				// pin tail points toward the bar growth direction (see markPointRotation below)
+				if negativeBar != reversed {
+					pointRotations[j] = -math.Pi / 2
+				} else {
+					pointRotations[j] = math.Pi / 2
+				}
 			}
 
 			if labelPainter != nil {
@@ -591,6 +654,7 @@ func (b *barChart) renderHorizontalBars(result *defaultRenderResult) (Box, error
 				}
 				labelPainter.Add(labelValue{
 					vertical:  false, // horizontal label
+					flipped:   negativeBar && !reversed && !labelLeft,
 					index:     index,
 					dataIndex: j,
 					value:     item,
@@ -664,6 +728,7 @@ func (b *barChart) renderHorizontalBars(result *defaultRenderResult) (Box, error
 					font:               series.Label.FontStyle.Font,
 					symbolSize:         series.MarkPoint.SymbolSize,
 					rotationRadians:    markPointRotation,
+					pointRotations:     pointRotations,
 					markpoints:         seriesMarks,
 					seriesValues:       series.Values,
 					points:             points,
@@ -675,13 +740,21 @@ func (b *barChart) renderHorizontalBars(result *defaultRenderResult) (Box, error
 				if globalSeriesData == nil {
 					globalSeriesData = sumSeriesData(opt.SeriesList, 0)
 				}
-				// global marks anchor to the value-end of the combined stack, not this series' points
-				globalPoints := make([]Point, len(accumulatedWidths))
-				for j := range accumulatedWidths {
+				// global marks anchor to the stack's outer edge on the side of the net sum
+				globalPoints := make([]Point, len(accumulatedPos))
+				globalRotations := make([]float64, len(accumulatedPos))
+				for j := range accumulatedPos {
 					reversedJ := yRange.divideCount - j - 1
 					y := divideValues[reversedJ] + margin
+					edge := accumulatedPos[reversedJ]
+					if accumulatedPos[reversedJ]+accumulatedNeg[reversedJ] < 0 {
+						edge = accumulatedNeg[reversedJ]
+						globalRotations[j] = -markPointRotation // pin flipped toward the stack tip
+					} else {
+						globalRotations[j] = markPointRotation
+					}
 					globalPoints[j] = Point{
-						X: baselineX + dir*accumulatedWidths[reversedJ],
+						X: baselineX + dir*edge,
 						Y: y + (barHeight >> 1),
 					}
 				}
@@ -690,6 +763,7 @@ func (b *barChart) renderHorizontalBars(result *defaultRenderResult) (Box, error
 					font:               series.Label.FontStyle.Font,
 					symbolSize:         series.MarkPoint.SymbolSize,
 					rotationRadians:    markPointRotation,
+					pointRotations:     globalRotations,
 					markpoints:         globalMarks,
 					seriesValues:       globalSeriesData,
 					points:             globalPoints,

--- a/bar_chart_test.go
+++ b/bar_chart_test.go
@@ -438,6 +438,98 @@ func TestBarChart(t *testing.T) {
 			},
 			pngCRC: 0x44a995f1,
 		},
+		{
+			name: "negative_values",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{-12, -5, -2, -5, -12, -19, -22, -19},
+					{-16, -9, -6, -9, -16, -23, -26, -23},
+				})
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+				return opt
+			},
+			pngCRC: 0x5da4b14a,
+		},
+		{
+			name: "mixed_sign",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{0, 7, 10, 7, 0, -7, -10, -7},
+					{10, 7, 0, -7, -10, -7, 0, 7},
+				})
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+				return opt
+			},
+			pngCRC: 0x9f4d96e3,
+		},
+		{
+			name: "stack_series_negative",
+			makeOptions: func() BarChartOption {
+				// mixed signs so stacks diverge above and below zero
+				opt := NewBarChartOptionWithData([][]float64{
+					{0, 7, 10, 7, 0, -7, -10, -7},
+					{-7, -10, -7, 0, 7, 10, 7, 0},
+					{3, 5, 3, 0, -3, -5, -3, 0},
+				})
+				opt.StackSeries = Ptr(true)
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+				return opt
+			},
+			pngCRC: 0x684cea37,
+		},
+		{
+			name: "stack_series_all_negative",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{-12, -5, -2, -5, -12, -19, -22, -19},
+					{-6, -2, -1, -2, -6, -9, -11, -9},
+				})
+				opt.StackSeries = Ptr(true)
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+				return opt
+			},
+			pngCRC: 0x54f6920e,
+		},
+		{
+			name: "rounded_caps_negative",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{5, 10, 5, -5, -10, -5},
+					{-10, -5, 5, 10, 5, -5},
+				})
+				opt.RoundedBarCaps = Ptr(true)
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F"}
+				return opt
+			},
+			pngCRC: 0x157db831,
+		},
+		{
+			name: "label_negative",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{5, 10, 5, -5, -10, -5},
+					{-10, -5, 5, 10, 5, -5},
+				})
+				for i := range opt.SeriesList {
+					opt.SeriesList[i].Label.Show = Ptr(true)
+				}
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F"}
+				return opt
+			},
+			pngCRC: 0x4558aa6c,
+		},
+		{
+			name: "mark_point_negative",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{5, 10, 5, -5, -10, -5},
+				})
+				opt.SeriesList[0].MarkPoint = NewMarkPoint(SeriesMarkTypeMin, SeriesMarkTypeMax)
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F"}
+				return opt
+			},
+			pngCRC: 0xa0a20d13,
+		},
 	}
 
 	for i, tt := range tests {
@@ -1013,6 +1105,105 @@ func TestBarChartHorizontal(t *testing.T) {
 				return opt
 			},
 			pngCRC: 0x7066191e,
+		},
+		{
+			name: "negative_values",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{-12, -5, -2, -5, -12, -19, -22, -19},
+					{-16, -9, -6, -9, -16, -23, -26, -23},
+				})
+				opt.Horizontal = true
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+				return opt
+			},
+			pngCRC: 0xdc0ceafc,
+		},
+		{
+			name: "mixed_sign",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{0, 7, 10, 7, 0, -7, -10, -7},
+					{10, 7, 0, -7, -10, -7, 0, 7},
+				})
+				opt.Horizontal = true
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+				return opt
+			},
+			pngCRC: 0xbe6a3016,
+		},
+		{
+			name: "mixed_sign_reversed",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{0, 7, 10, 7, 0, -7, -10, -7},
+					{10, 7, 0, -7, -10, -7, 0, 7},
+				})
+				opt.Horizontal = true
+				opt.CategoryAxis.Position = PositionRight
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+				return opt
+			},
+			pngCRC: 0x91215cf8,
+		},
+		{
+			name: "stack_series_negative",
+			makeOptions: func() BarChartOption {
+				// mixed signs so stacks diverge above and below zero
+				opt := NewBarChartOptionWithData([][]float64{
+					{0, 7, 10, 7, 0, -7, -10, -7},
+					{-7, -10, -7, 0, 7, 10, 7, 0},
+					{3, 5, 3, 0, -3, -5, -3, 0},
+				})
+				opt.Horizontal = true
+				opt.StackSeries = Ptr(true)
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F", "G", "H"}
+				return opt
+			},
+			pngCRC: 0xaadc92f3,
+		},
+		{
+			name: "rounded_caps_negative",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{5, 10, 5, -5, -10, -5},
+					{-10, -5, 5, 10, 5, -5},
+				})
+				opt.Horizontal = true
+				opt.RoundedBarCaps = Ptr(true)
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F"}
+				return opt
+			},
+			pngCRC: 0xadc6af8a,
+		},
+		{
+			name: "label_negative",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{5, 10, 5, -5, -10, -5},
+					{-10, -5, 5, 10, 5, -5},
+				})
+				for i := range opt.SeriesList {
+					opt.SeriesList[i].Label.Show = Ptr(true)
+				}
+				opt.Horizontal = true
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F"}
+				return opt
+			},
+			pngCRC: 0x741d1b05,
+		},
+		{
+			name: "mark_point_negative",
+			makeOptions: func() BarChartOption {
+				opt := NewBarChartOptionWithData([][]float64{
+					{5, 10, 5, -5, -10, -5},
+				})
+				opt.Horizontal = true
+				opt.SeriesList[0].MarkPoint = NewMarkPoint(SeriesMarkTypeMin, SeriesMarkTypeMax)
+				opt.CategoryAxis.Labels = []string{"A", "B", "C", "D", "E", "F"}
+				return opt
+			},
+			pngCRC: 0x71aeb0c8,
 		},
 	}
 

--- a/charts.go
+++ b/charts.go
@@ -288,6 +288,21 @@ func defaultRender(p *Painter, opt defaultRenderOption) (*defaultRenderResult, e
 		valueAxisRanges: make(map[int]axisRange),
 	}
 
+	// reserve fixed pixel headroom past the data extremes so mark point pins and series labels
+	// extending beyond the bars are not clipped; the pin head outer edge sits 5*symbolSize/4
+	// past the data point. Labels only need clearance toward the axis on negative extents,
+	// labels at the top or right render into the chart padding.
+	var markPointClearance, negativeClearance int
+	if symSize := opt.seriesList.markPointSize(); symSize > 0 {
+		markPointClearance = 5 * symSize / 4
+	}
+	negativeClearance = markPointClearance
+	if fontSize := opt.seriesList.labelFontSize(); fontSize > 0 {
+		labelClearance := 5 + // default label distance
+			p.MeasureText("0", 0, FontStyle{FontSize: fontSize, FontColor: ColorBlack}).Height()
+		negativeClearance = max(markPointClearance, labelClearance)
+	}
+
 	// calculate x-axis range and do a dry-render to find height
 	// we will render on the actual painter once we know the space the y-axis will occupy
 	var xAxisOpts axisOption
@@ -295,7 +310,7 @@ func defaultRender(p *Painter, opt defaultRenderOption) (*defaultRenderResult, e
 	if opt.categoryY {             // X is value axis
 		xValueAxis = opt.valueAxis[0]
 		xValueAxis.prep(getPreferredTheme(xValueAxis.Theme, theme), false)
-		xAxisRange := calculateValueAxisRange(p, false, p.Width(),
+		xPrep := prepareValueAxisRange(p, false, p.Width(),
 			xValueAxis.Min, xValueAxis.Max, xValueAxis.RangeValuePaddingScale,
 			xValueAxis.Labels,
 			xValueAxis.LabelCount, xValueAxis.Unit, xValueAxis.LabelCountAdjustment,
@@ -303,6 +318,15 @@ func defaultRender(p *Painter, opt defaultRenderOption) (*defaultRenderResult, e
 			getPreferredValueFormatter(xValueAxis.ValueFormatter, opt.valueFormatter),
 			xValueAxis.LabelRotation, xValueAxis.LabelFontStyle,
 			xValueAxis.PreferNiceIntervals)
+		if xPrep.minVal < 0 {
+			// clearance is historically not reserved on the x-axis; charts with negative extents
+			// enable it on both sides since pins can render at either bar tip
+			xPrep.maxClearancePx = markPointClearance
+			xPrep.minClearancePx = negativeClearance
+		}
+		flexCount := xValueAxis.LabelCount == 0 && !flagIs(false, xValueAxis.PreferNiceIntervals)
+		xMin, xMax, xLabelCount := resolveValueAxisRange(&xPrep, flexCount, 0)
+		xAxisRange := finalizeValueAxisRange(p, &xPrep, xMin, xMax, xLabelCount)
 		xAxisOpts = xValueAxis.toAxisOption(xAxisRange)
 	} else { // X is category axis (typical)
 		xAxisRange := calculateCategoryAxisRange(p, p.Width(), false, flagIs(false, opt.categoryAxis.BoundaryGap),
@@ -375,12 +399,6 @@ func defaultRender(p *Painter, opt defaultRenderOption) (*defaultRenderResult, e
 		var entries []yAxisEntry
 		var valuePreps []*valueAxisPrep
 		var valuePrepIndices []int
-		// reserve fixed pixel headroom above the data max so mark point pins are not clipped;
-		// the pin head outer edge sits 5*symbolSize/4 above the data point
-		var markPointClearance int
-		if symSize := opt.seriesList.markPointSize(); symSize > 0 {
-			markPointClearance = 5 * symSize / 4
-		}
 		if yAxisCount > 0 {
 			entries = make([]yAxisEntry, yAxisCount)
 			for yIndex := 0; yIndex < yAxisCount; yIndex++ {
@@ -407,6 +425,7 @@ func defaultRender(p *Painter, opt defaultRenderOption) (*defaultRenderResult, e
 					valueFormatter, yAxisOption.LabelRotation, yAxisOption.LabelFontStyle,
 					yAxisOption.PreferNiceIntervals)
 				prep.maxClearancePx = markPointClearance
+				prep.minClearancePx = negativeClearance // only takes effect when the data min is negative
 				entries[yIndex].prep = &prep
 				valuePreps = append(valuePreps, entries[yIndex].prep)
 				valuePrepIndices = append(valuePrepIndices, yIndex)

--- a/heat_map.go
+++ b/heat_map.go
@@ -300,6 +300,10 @@ func (h heatMapFakeSeries) markPointSize() int {
 	return 0
 }
 
+func (h heatMapFakeSeries) labelFontSize() float64 {
+	return 0
+}
+
 func (h heatMapFakeSeries) setSeriesName(_ int, _ string) {
 	// ignored
 }

--- a/mark_point.go
+++ b/mark_point.go
@@ -65,6 +65,7 @@ type markPointRenderOption struct {
 	font               *truetype.Font
 	symbolSize         int
 	rotationRadians    float64
+	pointRotations     []float64 // per-point rotation overrides, indexed like points
 	seriesValues       []float64
 	markpoints         []SeriesMark
 	seriesLabelPainter *seriesLabelPainter
@@ -120,6 +121,10 @@ func (m *markPointPainter) Render() (Box, error) {
 			if p.Y == math.MaxInt32 {
 				continue // skip null coordinate
 			}
+			rotation := opt.rotationRadians
+			if index < len(opt.pointRotations) {
+				rotation = opt.pointRotations[index]
+			}
 			if opt.seriesLabelPainter != nil {
 				// blank the label the MarkPoint replaces (rendered before series labels)
 				for i := range opt.seriesLabelPainter.values {
@@ -137,9 +142,9 @@ func (m *markPointPainter) Render() (Box, error) {
 			anchorOffsetX, anchorOffsetY := 0, -(opt.symbolSize >> 1)
 			headOuterOffsetX := 0
 			headOuterOffsetY := -(5 * opt.symbolSize) / 4
-			if opt.rotationRadians != 0 {
-				cos := math.Cos(opt.rotationRadians)
-				sin := math.Sin(opt.rotationRadians)
+			if rotation != 0 {
+				cos := math.Cos(rotation)
+				sin := math.Sin(rotation)
 				rotate := func(dx, dy int) (int, int) {
 					fx, fy := float64(dx), float64(dy)
 					return int(math.Round(cos*fx - sin*fy)),
@@ -150,7 +155,7 @@ func (m *markPointPainter) Render() (Box, error) {
 			}
 			drawnAnchorX, drawnAnchorY := p.X+anchorOffsetX, p.Y+anchorOffsetY
 			painter.MarkPin(drawnAnchorX, drawnAnchorY, opt.symbolSize,
-				opt.rotationRadians, opt.fillColor, opt.fillColor, 0.0)
+				rotation, opt.fillColor, opt.fillColor, 0.0)
 			text := opt.valueFormatter(value)
 			textBox := painter.MeasureText(text, 0, textStyle)
 			if textStyle.FontSize > smallLabelFontSize && textBox.Width() > opt.symbolSize {
@@ -159,10 +164,14 @@ func (m *markPointPainter) Render() (Box, error) {
 			}
 			const textInset = 2
 			var textX, textY int
-			if opt.rotationRadians == 0 {
+			if rotation == 0 {
 				// vertical pin: keep the horizontal centering on the head center
 				textX = drawnAnchorX - (textBox.Width() >> 1)
 				textY = drawnAnchorY - textInset
+			} else if rotation == math.Pi {
+				// flipped vertical pin (below the point): mirror of the default placement
+				textX = drawnAnchorX - (textBox.Width() >> 1)
+				textY = drawnAnchorY + textInset + textBox.Height()
 			} else {
 				// horizontal pin: anchor the text just inside the outer head curve
 				if headOuterOffsetX >= 0 {

--- a/range.go
+++ b/range.go
@@ -38,7 +38,8 @@ type valueAxisPrep struct {
 	minPadScale, maxPadScale float64
 	padLabelCount            int // estimated label count after collision check
 	maxLabelCount            int // max labels that fit the axis pixel size
-	maxClearancePx           int // fixed pixel headroom reserved above the data max (e.g. mark point pins)
+	maxClearancePx           int // pixel headroom above the data max for mark point pins
+	minClearancePx           int // pixel headroom below a negative data min for pins and flipped labels
 	preferNice               *bool
 	// carry-through for resolution and finalization
 	labelsCfg      []string
@@ -63,12 +64,15 @@ func prepareValueAxisRange(p *Painter, isVertical bool, axisSize int,
 	valueFormatter ValueFormatter,
 	labelRotation float64, fontStyle FontStyle,
 	preferNice *bool) valueAxisPrep {
-	minVal, maxVal, sumMax := getSeriesMinMaxSumMax(seriesList, yAxisIndex, stackSeries)
-	if stackSeries { // If stacked, maxVal should be the max per-index sum across all series
+	minVal, maxVal, sumMin, sumMax := getSeriesMinMaxSumMax(seriesList, yAxisIndex, stackSeries)
+	if stackSeries { // If stacked, maxVal should be the max cumulative sum across all series
 		if minVal > 0 {
 			minVal-- // subtract to ensure that all series are represented as a small stacked bar (may otherwise have 0 height)
 		}
 		maxVal = sumMax
+		if sumMin < minVal {
+			minVal = sumMin // negative values can stack below the item min
+		}
 	}
 	minPadScale, maxPadScale := 1.0, 1.0
 	if rangeValuePaddingScale != nil {
@@ -224,6 +228,20 @@ func resolveValueAxisRange(prep *valueAxisPrep, flexCount bool, targetLabelCount
 		maxPadded = clearanceFloor
 	}
 
+	// symmetric pixel clearance below the data min for marks on downward extending bars
+	var minClearanceFloor float64
+	if prep.minClearancePx > 0 && prep.minPadScale > 0 && prep.minVal < 0 &&
+		prep.axisSize > prep.minClearancePx && prep.minVal < maxPadded {
+		minClearanceFloor = maxPadded -
+			(maxPadded-prep.minVal)*float64(prep.axisSize)/float64(prep.axisSize-prep.minClearancePx)
+		if minClearanceFloor < minPadded {
+			minPadded = minClearanceFloor
+			if maxPadded-minPadded >= 10 {
+				minPadded = math.Floor(minPadded) // friendlier axis min when a whole unit is minor
+			}
+		}
+	}
+
 	// if the user set only a unit, we may need to refine again after padding to meet the unit
 	if prep.labelCountCfg == 0 && prep.labelUnit > 0 {
 		labelUnit := prep.labelUnit
@@ -342,7 +360,69 @@ func resolveValueAxisRange(prep *valueAxisPrep, flexCount bool, targetLabelCount
 		}
 	}
 
+	// when the padded range spans zero, align the interval grid so zero renders as a label
+	if prep.minCfg == nil && prep.maxCfg == nil && prep.labelUnit == 0 &&
+		prep.minPadScale > 0 && prep.maxPadScale > 0 && minPadded < 0 && maxPadded > 0 {
+		// clearance floors extend the covered extents so alignment retains the reserved headroom
+		alignMin := min(prep.minVal, minClearanceFloor)
+		alignMax := max(prep.maxVal, clearanceFloor)
+		minPadded, maxPadded = alignRangeToZero(minPadded, maxPadded, alignMin, alignMax, labelCount)
+	}
+
 	return minPadded, maxPadded, labelCount
+}
+
+// alignRangeToZero adjusts a zero-spanning padded range so zero lands exactly on the label
+// interval grid, keeping the label count fixed and never shrinking below the data extents.
+// When the data is entirely one-sided, the range is re-anchored so zero becomes the boundary.
+func alignRangeToZero(minPadded, maxPadded, dataMin, dataMax float64, labelCount int) (float64, float64) {
+	intervals := labelCount - 1
+	var required int // minimum intervals needed to cover each data side
+	if dataMin < 0 {
+		required++
+	}
+	if dataMax > 0 {
+		required++
+	}
+	if required == 0 || intervals < required {
+		return minPadded, maxPadded
+	}
+	interval := (maxPadded - minPadded) / float64(intervals)
+	if interval <= 0 {
+		return minPadded, maxPadded
+	}
+	if ratio := -minPadded / interval; math.Abs(ratio-math.Round(ratio)) < 1e-9 {
+		return minPadded, maxPadded // zero already on the grid
+	}
+	if dataMin < 0 && dataMax > 0 {
+		// with data on both sides the grid can absorb a friendlier interval without extreme
+		// padding, one-sided data instead keeps the tighter zero-anchored interval
+		interval = niceNumFrom(interval, extendedNiceNums[:])
+	}
+	// keep the current interval when the grid can cover the data, otherwise round the interval
+	// up to the next nice number until it fits
+	for {
+		var below, above int
+		if dataMin < 0 {
+			below = max(int(math.Ceil(-dataMin/interval-1e-9)), 1) // intervals below zero
+		}
+		if dataMax > 0 {
+			above = max(int(math.Ceil(dataMax/interval-1e-9)), 1) // intervals above zero
+		}
+		if below+above <= intervals {
+			for s := intervals - below - above; s > 0; s-- {
+				// surplus intervals go to the less padded side, one-sided data stays anchored at zero
+				if above == 0 || (below > 0 &&
+					float64(below)*interval+dataMin <= float64(above)*interval-dataMax) {
+					below++
+				} else {
+					above++
+				}
+			}
+			return -float64(below) * interval, float64(above) * interval
+		}
+		interval = niceNumFrom(interval*(1+1e-9), extendedNiceNums[:])
+	}
 }
 
 // finalizeValueAxisRange produces the final axisRange, regenerating labels if the range changed.
@@ -973,6 +1053,14 @@ func (r axisRange) getHeight(value float64) int {
 
 func (r axisRange) getRestHeight(value float64) int {
 	return r.size - r.getHeight(value)
+}
+
+// getHeightDelta returns the signed pixel span of a value delta, proportional to the range span.
+func (r axisRange) getHeightDelta(delta float64) int {
+	if r.max <= r.min {
+		return 0
+	}
+	return int(delta / (r.max - r.min) * float64(r.size))
 }
 
 // valuePosition returns the pixel offset (along the axis) of value, respecting r.reversed.

--- a/range_test.go
+++ b/range_test.go
@@ -89,6 +89,10 @@ func (tsl testSeriesList) markPointSize() int {
 	return 0
 }
 
+func (tsl testSeriesList) labelFontSize() float64 {
+	return 0
+}
+
 func (tsl testSeriesList) setSeriesName(_ int, _ string) {
 	panic("not implemented")
 }
@@ -373,6 +377,23 @@ func TestCalculateValueAxisRange(t *testing.T) {
 		assert.InDelta(t, 19.0, ar.min, 0.0)
 		assert.InDelta(t, 49, ar.max, 0.0)
 		assert.Equal(t, []string{"19", "49"}, ar.labels)
+	})
+
+	t.Run("stacked_negative_sum_min", func(t *testing.T) {
+		p := NewPainter(PainterOptions{Width: 800, Height: 600})
+
+		tsl := testSeriesList{
+			{values: []float64{5, -3}},
+			{values: []float64{-3, -3}},
+		}
+
+		ar := calculateValueAxisRange(p, true, 800, nil, nil, nil,
+			nil, 0, 0, 0,
+			tsl, 0, true, defaultValueFormatter, 0, fs, nil)
+
+		// axis must cover the negative stack extent (-6) and the positive stack extent (5)
+		assert.LessOrEqual(t, ar.min, -6.0)
+		assert.GreaterOrEqual(t, ar.max, 5.0)
 	})
 }
 
@@ -1239,8 +1260,8 @@ func TestAxisLabelQuality(t *testing.T) {
 		assert.Equal(t, len(axisQualitySizes)*axisQualitySampleCount, s.total)
 		assert.Equal(t, 0, s.coverageMiss)
 		assert.Equal(t, 30, s.goodLabelCount)
-		assert.Equal(t, 3894, s.topClose)
-		assert.Equal(t, 3008, s.bottomClose)
+		assert.Equal(t, 3910, s.topClose)
+		assert.Equal(t, 2958, s.bottomClose)
 		assert.Equal(t, 78, s.friendlyInterval)
 	})
 
@@ -1258,9 +1279,9 @@ func TestAxisLabelQuality(t *testing.T) {
 		assert.Equal(t, 12800, s.total)
 		assert.Equal(t, 0, s.coverageMiss)
 		assert.Equal(t, 3024, s.goodLabelCount)
-		assert.Equal(t, 3906, s.topClose)
-		assert.Equal(t, 9266, s.bottomClose)
-		assert.Equal(t, 7804, s.friendlyInterval)
+		assert.Equal(t, 5040, s.topClose)
+		assert.Equal(t, 6970, s.bottomClose)
+		assert.Equal(t, 7624, s.friendlyInterval)
 	})
 
 	t.Run("asymmetric_offset_width", func(t *testing.T) {
@@ -1296,8 +1317,8 @@ func TestAxisLabelQuality(t *testing.T) {
 		assert.Equal(t, 840, s.total)
 		assert.Equal(t, 0, s.coverageMiss)
 		assert.Equal(t, 238, s.goodLabelCount)
-		assert.Equal(t, 318, s.topClose)
-		assert.Equal(t, 566, s.bottomClose)
+		assert.Equal(t, 328, s.topClose)
+		assert.Equal(t, 554, s.bottomClose)
 		assert.Equal(t, 588, s.friendlyInterval)
 	})
 
@@ -1337,8 +1358,8 @@ func TestAxisLabelQuality(t *testing.T) {
 		assert.Equal(t, 4200, s.total)
 		assert.Equal(t, 0, s.coverageMiss)
 		assert.Equal(t, 4164, s.goodLabelCount)
-		assert.Equal(t, 630, s.topClose)
-		assert.Equal(t, 2458, s.bottomClose)
+		assert.Equal(t, 876, s.topClose)
+		assert.Equal(t, 2014, s.bottomClose)
 		assert.Equal(t, 0, s.friendlyInterval)
 	})
 }

--- a/series.go
+++ b/series.go
@@ -168,6 +168,14 @@ func (g GenericSeriesList) markPointSize() int {
 	return size
 }
 
+func (g GenericSeriesList) labelFontSize() float64 {
+	var size float64
+	for _, s := range g {
+		size = visibleLabelFontSize(s.Label, size)
+	}
+	return size
+}
+
 func (g GenericSeriesList) setSeriesName(index int, name string) {
 	g[index].Name = name
 }
@@ -271,6 +279,14 @@ func (l LineSeriesList) markPointSize() int {
 	var size int
 	for _, s := range l {
 		size = max(size, s.MarkPoint.effectiveSymbolSize())
+	}
+	return size
+}
+
+func (l LineSeriesList) labelFontSize() float64 {
+	var size float64
+	for _, s := range l {
+		size = visibleLabelFontSize(s.Label, size)
 	}
 	return size
 }
@@ -413,6 +429,14 @@ func (s ScatterSeriesList) markPointSize() int {
 	return 0
 }
 
+func (s ScatterSeriesList) labelFontSize() float64 {
+	var size float64
+	for _, series := range s {
+		size = visibleLabelFontSize(series.Label, size)
+	}
+	return size
+}
+
 func (s ScatterSeriesList) setSeriesName(index int, name string) {
 	s[index].Name = name
 }
@@ -536,6 +560,14 @@ func (b BarSeriesList) markPointSize() int {
 	return size
 }
 
+func (b BarSeriesList) labelFontSize() float64 {
+	var size float64
+	for _, s := range b {
+		size = visibleLabelFontSize(s.Label, size)
+	}
+	return size
+}
+
 func (b BarSeriesList) setSeriesName(index int, name string) {
 	b[index].Name = name
 }
@@ -624,6 +656,10 @@ func (f FunnelSeriesList) getSeriesSymbol(_ int) SymbolShape {
 
 func (f FunnelSeriesList) markPointSize() int {
 	return 0 // not supported on this chart type
+}
+
+func (f FunnelSeriesList) labelFontSize() float64 {
+	return 0 // no value axis on this chart type
 }
 
 func (f FunnelSeriesList) setSeriesName(index int, name string) {
@@ -734,6 +770,10 @@ func (p PieSeriesList) getSeriesSymbol(_ int) SymbolShape {
 
 func (p PieSeriesList) markPointSize() int {
 	return 0 // not supported on this chart type
+}
+
+func (p PieSeriesList) labelFontSize() float64 {
+	return 0 // no value axis on this chart type
 }
 
 func (p PieSeriesList) setSeriesName(index int, name string) {
@@ -847,6 +887,10 @@ func (d DoughnutSeriesList) markPointSize() int {
 	return 0 // not supported on this chart type
 }
 
+func (d DoughnutSeriesList) labelFontSize() float64 {
+	return 0 // no value axis on this chart type
+}
+
 func (d DoughnutSeriesList) setSeriesName(index int, name string) {
 	d[index].Name = name
 }
@@ -943,6 +987,10 @@ func (r RadarSeriesList) markPointSize() int {
 	return 0 // not supported on this chart type
 }
 
+func (r RadarSeriesList) labelFontSize() float64 {
+	return 0 // no value axis on this chart type
+}
+
 func (r RadarSeriesList) setSeriesName(index int, name string) {
 	r[index].Name = name
 }
@@ -982,11 +1030,24 @@ type seriesList interface {
 	getSeriesValues(index int) []float64
 	getSeriesLen(i int) int
 	names() []string
-	markPointSize() int // largest mark point pin width across series, 0 when none
+	markPointSize() int     // largest mark point pin width across series, 0 when none
+	labelFontSize() float64 // largest font size across series with labels shown, 0 when none
 	setSeriesName(index int, name string)
 	sortByNameIndex(dict map[string]int)
 	getSeriesSymbol(index int) SymbolShape
 	//SetSeriesLabels(label SeriesLabel) // informally included in interface (not used internally in interface)
+}
+
+// visibleLabelFontSize accumulates the largest configured font size among shown labels.
+func visibleLabelFontSize(label SeriesLabel, current float64) float64 {
+	if !flagIs(true, label.Show) {
+		return current
+	}
+	fontSize := label.FontStyle.FontSize
+	if fontSize == 0 {
+		fontSize = defaultLabelFontSize
+	}
+	return max(current, fontSize)
 }
 
 // series interface is used to provide the raw series struct to callers of seriesList, allowing direct type checks.
@@ -1297,15 +1358,19 @@ func nextStackedSeriesIndex(sl seriesList, index int) int {
 	return -1
 }
 
-// getSeriesMinMaxSumMax returns the min, max, and maximum sum of the series for a given y-axis index (either 0 or 1).
-// This is a higher performance option for internal use. calcSum provides an optimization to
-// only calculate the sumMax if it will be used.
-func getSeriesMinMaxSumMax(sl seriesList, yaxisIndex int, calcSum bool) (float64, float64, float64) {
+// getSeriesMinMaxSumMax returns the min, max, and min/max diverging stack sums of the series for
+// a given y-axis index (either 0 or 1). Positive and negative values sum separately per index,
+// matching diverging stack rendering. calcSum provides an optimization to only calculate the sum
+// extents if they will be used.
+func getSeriesMinMaxSumMax(sl seriesList, yaxisIndex int, calcSum bool) (float64, float64, float64, float64) {
 	minValue := math.MaxFloat64
 	maxValue := -math.MaxFloat64
-	var sums []float64
+	sumMin := math.MaxFloat64
+	sumMax := -math.MaxFloat64
+	var posSums, negSums []float64
 	if calcSum {
-		sums = make([]float64, getSeriesMaxDataCount(sl))
+		posSums = make([]float64, getSeriesMaxDataCount(sl))
+		negSums = make([]float64, len(posSums))
 	}
 	for i := 0; i < sl.len(); i++ {
 		series := sl.getSeries(i)
@@ -1324,28 +1389,37 @@ func getSeriesMinMaxSumMax(sl seriesList, yaxisIndex int, calcSum bool) (float64
 				minValue = item
 			}
 			if calcSum {
-				if valueIndex >= len(sums) {
-					sums = append(sums, make([]float64, valueIndex-len(sums)+1)...)
+				if valueIndex >= len(posSums) {
+					posSums = append(posSums, make([]float64, valueIndex-len(posSums)+1)...)
+					negSums = append(negSums, make([]float64, valueIndex-len(negSums)+1)...)
 				}
-				sums[valueIndex] += item
+				if item >= 0 {
+					posSums[valueIndex] += item
+					if posSums[valueIndex] > sumMax {
+						sumMax = posSums[valueIndex]
+					}
+				} else {
+					negSums[valueIndex] += item
+					if negSums[valueIndex] < sumMin {
+						sumMin = negSums[valueIndex]
+					}
+				}
 			}
 		}
 	}
-	maxSum := maxValue
-	if calcSum {
-		for _, val := range sums {
-			if val > maxSum {
-				maxSum = val
-			}
-		}
+	if maxValue > sumMax {
+		sumMax = maxValue
+	}
+	if sumMin == math.MaxFloat64 {
+		sumMin = minValue // no negative values to stack below zero
 	}
 	// If min was not updated then there were no valid data points. Return
 	// zeros to avoid propagating sentinel values like math.MaxFloat64 which
 	// can corrupt downstream range calculations.
 	if minValue == math.MaxFloat64 && maxValue == -math.MaxFloat64 {
-		return 0, 0, 0
+		return 0, 0, 0, 0
 	}
-	return minValue, maxValue, maxSum
+	return minValue, maxValue, sumMin, sumMax
 }
 
 // NewSeriesListGeneric returns a Generic series list for the given values and chart type (used in ChartOption).
@@ -1751,6 +1825,14 @@ func (k CandlestickSeriesList) getSeriesSymbol(_ int) SymbolShape {
 	return "" // no need to set symbol here, configured globally in candlestick_chart.go before defaultRender
 }
 
+func (k CandlestickSeriesList) labelFontSize() float64 {
+	var size float64
+	for _, s := range k {
+		size = visibleLabelFontSize(s.Label, size)
+	}
+	return size
+}
+
 func (k CandlestickSeriesList) markPointSize() int {
 	var size int
 	for _, s := range k {
@@ -2091,6 +2173,10 @@ func (vl ViolinSeriesList) getSeriesSymbol(_ int) SymbolShape {
 
 func (vl ViolinSeriesList) markPointSize() int {
 	return 0
+}
+
+func (vl ViolinSeriesList) labelFontSize() float64 {
+	return 0 // series labels are not supported on this chart type
 }
 
 func (vl ViolinSeriesList) setSeriesName(index int, name string) {

--- a/series_label.go
+++ b/series_label.go
@@ -256,6 +256,7 @@ type labelValue struct {
 	radians   float64
 	fontStyle FontStyle
 	vertical  bool
+	flipped   bool // place label below (vertical) or left (horizontal) of the anchor, for negative bars
 	offset    OffsetInt
 }
 
@@ -353,19 +354,30 @@ func (o *seriesLabelPainter) Add(value labelValue) {
 	}
 	if value.vertical {
 		renderValue.x -= textBox.Width() >> 1
-		renderValue.y -= distance
+		if value.flipped {
+			renderValue.y += distance + textBox.Height()
+		} else {
+			renderValue.y -= distance
+		}
 	} else {
-		// Start with default positioning
-		renderValue.x += distance
+		if value.flipped {
+			renderValue.x -= distance + textBox.Width()
+			if renderValue.x < 0 {
+				renderValue.x = 0 // slide right to stay within bounds
+			}
+		} else {
+			// Start with default positioning
+			renderValue.x += distance
 
-		// Check if label would extend beyond painter width boundary and adjust if needed
-		// Allow labels to extend into the right padding space if configured
-		maxAllowedX := o.p.Width() + o.rightPadding
-		labelEndX := renderValue.x + textBox.Width()
-		if labelEndX > maxAllowedX {
-			// Slide label left just enough to keep it within bounds (including padding)
-			overhang := labelEndX - maxAllowedX
-			renderValue.x -= overhang
+			// Check if label would extend beyond painter width boundary and adjust if needed
+			// Allow labels to extend into the right padding space if configured
+			maxAllowedX := o.p.Width() + o.rightPadding
+			labelEndX := renderValue.x + textBox.Width()
+			if labelEndX > maxAllowedX {
+				// Slide label left just enough to keep it within bounds (including padding)
+				overhang := labelEndX - maxAllowedX
+				renderValue.x -= overhang
+			}
 		}
 
 		renderValue.y += textBox.Height() >> 1

--- a/series_test.go
+++ b/series_test.go
@@ -37,8 +37,9 @@ func TestSeriesLists(t *testing.T) {
 				require.Fail(t, "Need to implement chart type test")
 			}
 
-			min, max, maxSum := getSeriesMinMaxSumMax(seriesList, 0, true)
-			assert.InDelta(t, float64(12), maxSum, 0)
+			min, max, sumMin, sumMax := getSeriesMinMaxSumMax(seriesList, 0, true)
+			assert.InDelta(t, float64(12), sumMax, 0)
+			assert.InDelta(t, float64(1), sumMin, 0)
 			assert.InDelta(t, float64(10), max, 0)
 			assert.InDelta(t, float64(1), min, 0)
 		})
@@ -225,10 +226,11 @@ func TestGetSeriesMinMaxSumMaxViolin(t *testing.T) {
 		{{0.3, 0.4}},
 	})
 
-	min, max, maxSum := getSeriesMinMaxSumMax(seriesList, 0, true)
+	min, max, sumMin, sumMax := getSeriesMinMaxSumMax(seriesList, 0, true)
 	assert.InDelta(t, -0.8, min, 0.0)
 	assert.InDelta(t, 0.8, max, 0.0)
-	assert.InDelta(t, 0.8, maxSum, 0.0)
+	assert.InDelta(t, -0.8, sumMin, 0.0)
+	assert.InDelta(t, 0.8, sumMax, 0.0)
 }
 
 func TestGetSeriesMinMaxSumMaxViolinGeneric(t *testing.T) {
@@ -239,10 +241,11 @@ func TestGetSeriesMinMaxSumMaxViolinGeneric(t *testing.T) {
 		{{0.3, 0.4}},
 	}).ToGenericSeriesList()
 
-	min, max, maxSum := getSeriesMinMaxSumMax(generic, 0, true)
+	min, max, sumMin, sumMax := getSeriesMinMaxSumMax(generic, 0, true)
 	assert.InDelta(t, -0.8, min, 0.0)
 	assert.InDelta(t, 0.8, max, 0.0)
-	assert.InDelta(t, 0.8, maxSum, 0.0)
+	assert.InDelta(t, -0.8, sumMin, 0.0)
+	assert.InDelta(t, 0.8, sumMax, 0.0)
 }
 
 func TestNewSeriesListViolin(t *testing.T) {
@@ -268,16 +271,47 @@ func TestGetSeriesMinMaxSumMaxEmpty(t *testing.T) {
 	t.Parallel()
 
 	empty := NewSeriesListLine([][]float64{{}})
-	min, max, sum := getSeriesMinMaxSumMax(empty, 0, true)
+	min, max, sumMin, sumMax := getSeriesMinMaxSumMax(empty, 0, true)
 	assert.InDelta(t, 0.0, min, 0)
 	assert.InDelta(t, 0.0, max, 0)
-	assert.InDelta(t, 0.0, sum, 0)
+	assert.InDelta(t, 0.0, sumMin, 0)
+	assert.InDelta(t, 0.0, sumMax, 0)
 
 	nullVals := NewSeriesListLine([][]float64{{GetNullValue(), GetNullValue()}})
-	min, max, sum = getSeriesMinMaxSumMax(nullVals, 0, true)
+	min, max, sumMin, sumMax = getSeriesMinMaxSumMax(nullVals, 0, true)
 	assert.InDelta(t, 0.0, min, 0)
 	assert.InDelta(t, 0.0, max, 0)
-	assert.InDelta(t, 0.0, sum, 0)
+	assert.InDelta(t, 0.0, sumMin, 0)
+	assert.InDelta(t, 0.0, sumMax, 0)
+}
+
+func TestGetSeriesMinMaxSumMaxNegative(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mixed_sign", func(t *testing.T) {
+		seriesList := NewSeriesListBar([][]float64{
+			{3, -3},
+			{3, -3},
+			{-4, -3},
+		})
+		min, max, sumMin, sumMax := getSeriesMinMaxSumMax(seriesList, 0, true)
+		assert.InDelta(t, -4.0, min, 0)
+		assert.InDelta(t, 3.0, max, 0)
+		assert.InDelta(t, -9.0, sumMin, 0)
+		assert.InDelta(t, 6.0, sumMax, 0) // positive stack extent, above the net sum of 2
+	})
+
+	t.Run("null_interleaved", func(t *testing.T) {
+		seriesList := NewSeriesListBar([][]float64{
+			{5, GetNullValue()},
+			{-3, -6},
+		})
+		min, max, sumMin, sumMax := getSeriesMinMaxSumMax(seriesList, 0, true)
+		assert.InDelta(t, -6.0, min, 0)
+		assert.InDelta(t, 5.0, max, 0)
+		assert.InDelta(t, -6.0, sumMin, 0)
+		assert.InDelta(t, 5.0, sumMax, 0)
+	})
 }
 
 func TestExpandSingleValueScatterSeries(t *testing.T) {
@@ -832,7 +866,7 @@ func BenchmarkGetSeriesMinMaxSumMax(b *testing.B) { // benchmark used to evaluat
 	}
 
 	for i := 0; i < b.N; i++ {
-		_, _, _ = getSeriesMinMaxSumMax(seriesList, 0, true)
+		_, _, _, _ = getSeriesMinMaxSumMax(seriesList, 0, true)
 	}
 }
 

--- a/testdata/svg/bar_chart_test/TestBarChart/28-negative_values.svg
+++ b/testdata/svg/bar_chart_test/TestBarChart/28-negative_values.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><text x="33" y="26" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="28" y="81" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-5</text><text x="19" y="137" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-10</text><text x="19" y="192" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-15</text><text x="19" y="248" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-20</text><text x="19" y="303" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-25</text><text x="19" y="359" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-30</text><path d="M 49 20
+L 580 20" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 75
+L 580 75" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 131
+L 580 131" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 187
+L 580 187" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 243
+L 580 243" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 299
+L 580 299" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 53 355
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 53 360
+L 53 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 118 360
+L 118 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 184 360
+L 184 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 250 360
+L 250 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 316 360
+L 316 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 382 360
+L 382 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 448 360
+L 448 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 514 360
+L 514 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 580 360
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="80" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="146" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="212" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="278" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="344" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="411" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="476" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">G</text><text x="541" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">H</text><path d="M 63 21
+L 83 21
+L 83 154
+L 63 154
+L 63 21" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 128 21
+L 148 21
+L 148 76
+L 128 76
+L 128 21" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 194 21
+L 214 21
+L 214 43
+L 194 43
+L 194 21" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 260 21
+L 280 21
+L 280 76
+L 260 76
+L 260 21" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 326 21
+L 346 21
+L 346 154
+L 326 154
+L 326 21" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 392 21
+L 412 21
+L 412 233
+L 392 233
+L 392 21" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 458 21
+L 478 21
+L 478 266
+L 458 266
+L 458 21" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 524 21
+L 544 21
+L 544 233
+L 524 233
+L 524 21" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 88 21
+L 108 21
+L 108 199
+L 88 199
+L 88 21" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 153 21
+L 173 21
+L 173 121
+L 153 121
+L 153 21" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 219 21
+L 239 21
+L 239 87
+L 219 87
+L 219 21" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 285 21
+L 305 21
+L 305 121
+L 285 121
+L 285 21" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 351 21
+L 371 21
+L 371 199
+L 351 199
+L 351 21" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 417 21
+L 437 21
+L 437 277
+L 417 277
+L 417 21" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 483 21
+L 503 21
+L 503 311
+L 483 311
+L 483 21" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 549 21
+L 569 21
+L 569 277
+L 549 277
+L 549 21" style="stroke:none;fill:rgb(145,204,117)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChart/29-mixed_sign.svg
+++ b/testdata/svg/bar_chart_test/TestBarChart/29-mixed_sign.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><text x="19" y="26" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">12.5</text><text x="32" y="63" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">10</text><text x="28" y="100" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">7.5</text><text x="41" y="137" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">5</text><text x="28" y="174" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">2.5</text><text x="41" y="211" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="22" y="248" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-2.5</text><text x="36" y="285" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-5</text><text x="22" y="322" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-7.5</text><text x="27" y="359" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-10</text><path d="M 57 20
+L 580 20" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 57
+L 580 57" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 94
+L 580 94" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 131
+L 580 131" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 168
+L 580 168" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 206
+L 580 206" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 243
+L 580 243" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 280
+L 580 280" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 317
+L 580 317" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 61 355
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 61 360
+L 61 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 125 360
+L 125 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 190 360
+L 190 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 255 360
+L 255 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 320 360
+L 320 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 385 360
+L 385 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 450 360
+L 450 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 515 360
+L 515 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 580 360
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="88" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="152" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="217" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="282" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="347" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="413" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="477" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">G</text><text x="541" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">H</text><path d="M 71 207
+L 90 207
+L 90 206
+L 71 206
+L 71 207" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 135 102
+L 154 102
+L 154 206
+L 135 206
+L 135 102" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 200 58
+L 219 58
+L 219 206
+L 200 206
+L 200 58" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 265 102
+L 284 102
+L 284 206
+L 265 206
+L 265 102" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 330 207
+L 349 207
+L 349 206
+L 330 206
+L 330 207" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 395 208
+L 414 208
+L 414 311
+L 395 311
+L 395 208" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 460 208
+L 479 208
+L 479 355
+L 460 355
+L 460 208" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 525 208
+L 544 208
+L 544 311
+L 525 311
+L 525 208" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 95 58
+L 114 58
+L 114 206
+L 95 206
+L 95 58" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 159 102
+L 178 102
+L 178 206
+L 159 206
+L 159 102" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 224 207
+L 243 207
+L 243 206
+L 224 206
+L 224 207" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 289 208
+L 308 208
+L 308 311
+L 289 311
+L 289 208" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 354 208
+L 373 208
+L 373 355
+L 354 355
+L 354 208" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 419 208
+L 438 208
+L 438 311
+L 419 311
+L 419 208" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 484 207
+L 503 207
+L 503 206
+L 484 206
+L 484 207" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 549 102
+L 568 102
+L 568 206
+L 549 206
+L 549 102" style="stroke:none;fill:rgb(145,204,117)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChart/30-stack_series_negative.svg
+++ b/testdata/svg/bar_chart_test/TestBarChart/30-stack_series_negative.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><text x="24" y="26" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">15</text><text x="24" y="56" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">12</text><text x="33" y="86" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">9</text><text x="33" y="116" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">6</text><text x="33" y="147" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">3</text><text x="33" y="177" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="28" y="207" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-3</text><text x="28" y="237" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-6</text><text x="28" y="268" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-9</text><text x="19" y="298" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-12</text><text x="19" y="328" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-15</text><text x="19" y="359" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-18</text><path d="M 49 20
+L 580 20" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 50
+L 580 50" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 80
+L 580 80" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 111
+L 580 111" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 141
+L 580 141" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 172
+L 580 172" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 202
+L 580 202" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 233
+L 580 233" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 263
+L 580 263" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 294
+L 580 294" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 324
+L 580 324" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 53 355
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 53 360
+L 53 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 118 360
+L 118 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 184 360
+L 184 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 250 360
+L 250 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 316 360
+L 316 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 382 360
+L 382 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 448 360
+L 448 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 514 360
+L 514 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 580 360
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="80" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="146" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="212" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="278" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="344" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="411" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="476" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">G</text><text x="541" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">H</text><path d="M 63 173
+L 108 173
+L 108 173
+L 63 173
+L 63 173" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 128 102
+L 173 102
+L 173 173
+L 128 173
+L 128 102" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 194 72
+L 239 72
+L 239 173
+L 194 173
+L 194 72" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 260 102
+L 305 102
+L 305 173
+L 260 173
+L 260 102" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 326 173
+L 371 173
+L 371 173
+L 326 173
+L 326 173" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 392 173
+L 437 173
+L 437 244
+L 392 244
+L 392 173" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 458 173
+L 503 173
+L 503 274
+L 458 274
+L 458 173" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 524 173
+L 569 173
+L 569 244
+L 524 244
+L 524 173" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 63 173
+L 108 173
+L 108 244
+L 63 244
+L 63 173" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 128 173
+L 173 173
+L 173 274
+L 128 274
+L 128 173" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 194 173
+L 239 173
+L 239 244
+L 194 244
+L 194 173" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 260 102
+L 305 102
+L 305 102
+L 260 102
+L 260 102" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 326 102
+L 371 102
+L 371 173
+L 326 173
+L 326 102" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 392 72
+L 437 72
+L 437 173
+L 392 173
+L 392 72" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 458 102
+L 503 102
+L 503 173
+L 458 173
+L 458 102" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 524 173
+L 569 173
+L 569 173
+L 524 173
+L 524 173" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 63 143
+L 108 143
+L 108 173
+L 63 173
+L 63 143" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 128 52
+L 173 52
+L 173 102
+L 128 102
+L 128 52" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 194 42
+L 239 42
+L 239 72
+L 194 72
+L 194 42" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 260 102
+L 305 102
+L 305 102
+L 260 102
+L 260 102" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 326 173
+L 371 173
+L 371 203
+L 326 203
+L 326 173" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 392 244
+L 437 244
+L 437 294
+L 392 294
+L 392 244" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 458 274
+L 503 274
+L 503 304
+L 458 304
+L 458 274" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 524 173
+L 569 173
+L 569 173
+L 524 173
+L 524 173" style="stroke:none;fill:rgb(250,200,88)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChart/31-stack_series_all_negative.svg
+++ b/testdata/svg/bar_chart_test/TestBarChart/31-stack_series_all_negative.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><text x="33" y="26" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="28" y="67" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-5</text><text x="19" y="109" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-10</text><text x="19" y="150" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-15</text><text x="19" y="192" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-20</text><text x="19" y="234" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-25</text><text x="19" y="275" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-30</text><text x="19" y="317" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-35</text><text x="19" y="359" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-40</text><path d="M 49 20
+L 580 20" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 61
+L 580 61" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 103
+L 580 103" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 145
+L 580 145" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 187
+L 580 187" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 229
+L 580 229" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 271
+L 580 271" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 313
+L 580 313" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 53 355
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 53 360
+L 53 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 118 360
+L 118 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 184 360
+L 184 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 250 360
+L 250 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 316 360
+L 316 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 382 360
+L 382 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 448 360
+L 448 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 514 360
+L 514 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 580 360
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="80" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="146" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="212" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="278" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="344" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="411" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="476" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">G</text><text x="541" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">H</text><path d="M 63 20
+L 108 20
+L 108 120
+L 63 120
+L 63 20" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 128 20
+L 173 20
+L 173 61
+L 128 61
+L 128 20" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 194 20
+L 239 20
+L 239 36
+L 194 36
+L 194 20" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 260 20
+L 305 20
+L 305 61
+L 260 61
+L 260 20" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 326 20
+L 371 20
+L 371 120
+L 326 120
+L 326 20" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 392 20
+L 437 20
+L 437 179
+L 392 179
+L 392 20" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 458 20
+L 503 20
+L 503 204
+L 458 204
+L 458 20" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 524 20
+L 569 20
+L 569 179
+L 524 179
+L 524 20" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 63 120
+L 108 120
+L 108 170
+L 63 170
+L 63 120" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 128 61
+L 173 61
+L 173 77
+L 128 77
+L 128 61" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 194 36
+L 239 36
+L 239 44
+L 194 44
+L 194 36" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 260 61
+L 305 61
+L 305 77
+L 260 77
+L 260 61" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 326 120
+L 371 120
+L 371 170
+L 326 170
+L 326 120" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 392 179
+L 437 179
+L 437 254
+L 392 254
+L 392 179" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 458 204
+L 503 204
+L 503 296
+L 458 296
+L 458 204" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 524 179
+L 569 179
+L 569 254
+L 524 254
+L 524 179" style="stroke:none;fill:rgb(145,204,117)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChart/32-rounded_caps_negative.svg
+++ b/testdata/svg/bar_chart_test/TestBarChart/32-rounded_caps_negative.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><text x="19" y="26" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">12.5</text><text x="32" y="63" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">10</text><text x="28" y="100" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">7.5</text><text x="41" y="137" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">5</text><text x="28" y="174" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">2.5</text><text x="41" y="211" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="22" y="248" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-2.5</text><text x="36" y="285" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-5</text><text x="22" y="322" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-7.5</text><text x="27" y="359" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-10</text><path d="M 57 20
+L 580 20" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 57
+L 580 57" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 94
+L 580 94" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 131
+L 580 131" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 168
+L 580 168" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 206
+L 580 206" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 243
+L 580 243" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 280
+L 580 280" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 57 317
+L 580 317" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 61 355
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 61 360
+L 61 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 147 360
+L 147 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 234 360
+L 234 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 320 360
+L 320 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 407 360
+L 407 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 493 360
+L 493 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 580 360
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="99" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="185" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="272" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="358" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="445" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="532" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><path d="M 86 132
+L 86 132
+L 86 132
+A 15 15 0 0 1 101 147
+L 101 206
+L 71 206
+L 71 147
+L 71 147
+A 15 15 0 0 1 86 132
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 172 58
+L 172 58
+L 172 58
+A 15 15 0 0 1 187 73
+L 187 206
+L 157 206
+L 157 73
+L 157 73
+A 15 15 0 0 1 172 58
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 259 132
+L 259 132
+L 259 132
+A 15 15 0 0 1 274 147
+L 274 206
+L 244 206
+L 244 147
+L 244 147
+A 15 15 0 0 1 259 132
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 330 208
+L 360 208
+L 360 266
+L 360 266
+A 15 15 0 0 1 345 281
+L 345 281
+L 345 281
+A 15 15 0 0 1 330 266
+L 330 208
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 417 208
+L 447 208
+L 447 340
+L 447 340
+A 15 15 0 0 1 432 355
+L 432 355
+L 432 355
+A 15 15 0 0 1 417 340
+L 417 208
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 503 208
+L 533 208
+L 533 266
+L 533 266
+A 15 15 0 0 1 518 281
+L 518 281
+L 518 281
+A 15 15 0 0 1 503 266
+L 503 208
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 106 208
+L 136 208
+L 136 340
+L 136 340
+A 15 15 0 0 1 121 355
+L 121 355
+L 121 355
+A 15 15 0 0 1 106 340
+L 106 208
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 192 208
+L 222 208
+L 222 266
+L 222 266
+A 15 15 0 0 1 207 281
+L 207 281
+L 207 281
+A 15 15 0 0 1 192 266
+L 192 208
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 294 132
+L 294 132
+L 294 132
+A 15 15 0 0 1 309 147
+L 309 206
+L 279 206
+L 279 147
+L 279 147
+A 15 15 0 0 1 294 132
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 380 58
+L 380 58
+L 380 58
+A 15 15 0 0 1 395 73
+L 395 206
+L 365 206
+L 365 73
+L 365 73
+A 15 15 0 0 1 380 58
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 467 132
+L 467 132
+L 467 132
+A 15 15 0 0 1 482 147
+L 482 206
+L 452 206
+L 452 147
+L 452 147
+A 15 15 0 0 1 467 132
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 538 208
+L 568 208
+L 568 266
+L 568 266
+A 15 15 0 0 1 553 281
+L 553 281
+L 553 281
+A 15 15 0 0 1 538 266
+L 538 208
+Z" style="stroke:none;fill:rgb(145,204,117)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChart/33-label_negative.svg
+++ b/testdata/svg/bar_chart_test/TestBarChart/33-label_negative.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><text x="24" y="26" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">12</text><text x="33" y="63" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">9</text><text x="33" y="100" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">6</text><text x="33" y="137" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">3</text><text x="33" y="174" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="28" y="211" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-3</text><text x="28" y="248" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-6</text><text x="28" y="285" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-9</text><text x="19" y="322" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-12</text><text x="19" y="359" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-15</text><path d="M 49 20
+L 580 20" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 57
+L 580 57" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 94
+L 580 94" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 131
+L 580 131" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 168
+L 580 168" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 206
+L 580 206" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 243
+L 580 243" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 280
+L 580 280" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 317
+L 580 317" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 53 355
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 53 360
+L 53 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 140 360
+L 140 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 228 360
+L 228 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 316 360
+L 316 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 404 360
+L 404 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 492 360
+L 492 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 580 360
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="91" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="179" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="267" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="355" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="443" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="532" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><path d="M 63 107
+L 94 107
+L 94 168
+L 63 168
+L 63 107" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 150 45
+L 181 45
+L 181 168
+L 150 168
+L 150 45" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 238 107
+L 269 107
+L 269 168
+L 238 168
+L 238 107" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 326 170
+L 357 170
+L 357 231
+L 326 231
+L 326 170" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 414 170
+L 445 170
+L 445 293
+L 414 293
+L 414 170" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 502 170
+L 533 170
+L 533 231
+L 502 231
+L 502 170" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 99 170
+L 130 170
+L 130 293
+L 99 293
+L 99 170" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 186 170
+L 217 170
+L 217 231
+L 186 231
+L 186 170" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 274 107
+L 305 107
+L 305 168
+L 274 168
+L 274 107" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 362 45
+L 393 45
+L 393 168
+L 362 168
+L 362 45" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 450 107
+L 481 107
+L 481 168
+L 450 168
+L 450 107" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 538 170
+L 569 170
+L 569 231
+L 538 231
+L 538 170" style="stroke:none;fill:rgb(145,204,117)"/><text x="74" y="102" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">5</text><text x="157" y="40" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">10</text><text x="249" y="102" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">5</text><text x="335" y="250" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-5</text><text x="419" y="312" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-10</text><text x="511" y="250" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-5</text><text x="104" y="312" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-10</text><text x="195" y="250" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-5</text><text x="285" y="102" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">5</text><text x="369" y="40" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">10</text><text x="461" y="102" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">5</text><text x="547" y="250" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-5</text></svg>

--- a/testdata/svg/bar_chart_test/TestBarChart/34-mark_point_negative.svg
+++ b/testdata/svg/bar_chart_test/TestBarChart/34-mark_point_negative.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><text x="24" y="26" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">16</text><text x="24" y="63" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">12</text><text x="33" y="100" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">8</text><text x="33" y="137" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">4</text><text x="33" y="174" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="28" y="211" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-4</text><text x="28" y="248" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-8</text><text x="19" y="285" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-12</text><text x="19" y="322" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-16</text><text x="19" y="359" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-20</text><path d="M 49 20
+L 580 20" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 57
+L 580 57" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 94
+L 580 94" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 131
+L 580 131" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 168
+L 580 168" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 206
+L 580 206" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 243
+L 580 243" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 280
+L 580 280" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 49 317
+L 580 317" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 53 355
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 53 360
+L 53 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 140 360
+L 140 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 228 360
+L 228 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 316 360
+L 316 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 404 360
+L 404 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 492 360
+L 492 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 580 360
+L 580 355" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="91" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="179" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="267" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="355" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="443" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="532" y="378" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><path d="M 63 123
+L 130 123
+L 130 168
+L 63 168
+L 63 123" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 150 76
+L 217 76
+L 217 168
+L 150 168
+L 150 76" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 238 123
+L 305 123
+L 305 168
+L 238 168
+L 238 123" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 326 170
+L 393 170
+L 393 216
+L 326 216
+L 326 170" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 414 170
+L 481 170
+L 481 262
+L 414 262
+L 414 170" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 502 170
+L 569 170
+L 569 216
+L 502 216
+L 502 170" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 450.62 269.48
+A 14 14 0 1 1 443.38 269.48
+L 447 283
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 461 283
+Q447,248 433,283
+Z" style="stroke:none;fill:rgb(84,112,198)"/><text x="437" y="292" style="stroke:none;fill:rgb(238,238,238);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-10</text><path d="M 179.38 68.52
+A 14 14 0 1 1 186.62 68.52
+L 183 55
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 169 55
+Q183,90 197,55
+Z" style="stroke:none;fill:rgb(84,112,198)"/><text x="175" y="60" style="stroke:none;fill:rgb(238,238,238);font-size:13.3px;font-family:'Roboto Medium',sans-serif">10</text></svg>

--- a/testdata/svg/bar_chart_test/TestBarChartHorizontal/24-negative_values.svg
+++ b/testdata/svg/bar_chart_test/TestBarChartHorizontal/24-negative_values.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><path d="M 41 20
+L 41 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 20
+L 41 20" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 62
+L 41 62" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 104
+L 41 104" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 146
+L 41 146" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 188
+L 41 188" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 230
+L 41 230" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 272
+L 41 272" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 314
+L 41 314" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 356
+L 41 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="19" y="46" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">H</text><text x="20" y="88" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">G</text><text x="22" y="130" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="21" y="172" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="20" y="213" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="20" y="255" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="20" y="297" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="20" y="339" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="41" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-30</text><text x="130" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-25</text><text x="220" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-20</text><text x="310" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-15</text><text x="399" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-10</text><text x="489" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-5</text><text x="570" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><path d="M 131 20
+L 131 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 221 20
+L 221 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 311 20
+L 311 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 400 20
+L 400 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 490 20
+L 490 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 580 20
+L 580 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 364 319
+L 580 319
+L 580 333
+L 364 333
+L 364 319" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 490 277
+L 580 277
+L 580 291
+L 490 291
+L 490 277" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 544 235
+L 580 235
+L 580 249
+L 544 249
+L 544 235" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 490 193
+L 580 193
+L 580 207
+L 490 207
+L 490 193" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 364 151
+L 580 151
+L 580 165
+L 364 165
+L 364 151" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 239 109
+L 580 109
+L 580 123
+L 239 123
+L 239 109" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 185 67
+L 580 67
+L 580 81
+L 185 81
+L 185 67" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 239 25
+L 580 25
+L 580 39
+L 239 39
+L 239 25" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 293 336
+L 580 336
+L 580 350
+L 293 350
+L 293 336" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 418 294
+L 580 294
+L 580 308
+L 418 308
+L 418 294" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 472 252
+L 580 252
+L 580 266
+L 472 266
+L 472 252" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 418 210
+L 580 210
+L 580 224
+L 418 224
+L 418 210" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 293 168
+L 580 168
+L 580 182
+L 293 182
+L 293 168" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 167 126
+L 580 126
+L 580 140
+L 167 140
+L 167 126" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 113 84
+L 580 84
+L 580 98
+L 113 98
+L 113 84" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 167 42
+L 580 42
+L 580 56
+L 167 56
+L 167 42" style="stroke:none;fill:rgb(145,204,117)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChartHorizontal/25-mixed_sign.svg
+++ b/testdata/svg/bar_chart_test/TestBarChartHorizontal/25-mixed_sign.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><path d="M 41 20
+L 41 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 20
+L 41 20" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 62
+L 41 62" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 104
+L 41 104" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 146
+L 41 146" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 188
+L 41 188" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 230
+L 41 230" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 272
+L 41 272" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 314
+L 41 314" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 356
+L 41 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="19" y="46" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">H</text><text x="20" y="88" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">G</text><text x="22" y="130" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="21" y="172" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="20" y="213" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="20" y="255" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="20" y="297" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="20" y="339" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="41" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-10</text><text x="148" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-5</text><text x="256" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="363" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">5</text><text x="471" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">10</text><text x="561" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">15</text><path d="M 149 20
+L 149 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 257 20
+L 257 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 364 20
+L 364 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 472 20
+L 472 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 580 20
+L 580 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 257 319
+L 257 319
+L 257 333
+L 257 333
+L 257 319" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 257 277
+L 407 277
+L 407 291
+L 257 291
+L 257 277" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 257 235
+L 472 235
+L 472 249
+L 257 249
+L 257 235" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 257 193
+L 407 193
+L 407 207
+L 257 207
+L 257 193" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 257 151
+L 257 151
+L 257 165
+L 257 165
+L 257 151" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 106 109
+L 257 109
+L 257 123
+L 106 123
+L 106 109" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 42 67
+L 257 67
+L 257 81
+L 42 81
+L 42 67" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 106 25
+L 257 25
+L 257 39
+L 106 39
+L 106 25" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 257 336
+L 472 336
+L 472 350
+L 257 350
+L 257 336" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 257 294
+L 407 294
+L 407 308
+L 257 308
+L 257 294" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 257 252
+L 257 252
+L 257 266
+L 257 266
+L 257 252" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 106 210
+L 257 210
+L 257 224
+L 106 224
+L 106 210" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 42 168
+L 257 168
+L 257 182
+L 42 182
+L 42 168" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 106 126
+L 257 126
+L 257 140
+L 106 140
+L 106 126" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 257 84
+L 257 84
+L 257 98
+L 257 98
+L 257 84" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 257 42
+L 407 42
+L 407 56
+L 257 56
+L 257 42" style="stroke:none;fill:rgb(145,204,117)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChartHorizontal/26-mixed_sign_reversed.svg
+++ b/testdata/svg/bar_chart_test/TestBarChartHorizontal/26-mixed_sign_reversed.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><path d="M 559 20
+L 559 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 559 20
+L 564 20" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 559 62
+L 564 62" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 559 104
+L 564 104" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 559 146
+L 564 146" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 559 188
+L 564 188" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 559 230
+L 564 230" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 559 272
+L 564 272" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 559 314
+L 564 314" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 559 356
+L 564 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="569" y="46" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">H</text><text x="569" y="88" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">G</text><text x="569" y="130" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="569" y="172" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="569" y="213" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="569" y="255" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="569" y="297" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="569" y="339" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="19" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">15</text><text x="126" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">10</text><text x="234" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">5</text><text x="341" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="449" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-5</text><text x="534" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-10</text><path d="M 127 20
+L 127 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 235 20
+L 235 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 342 20
+L 342 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 450 20
+L 450 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 558 20
+L 558 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 343 319
+L 343 319
+L 343 333
+L 343 333
+L 343 319" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 193 277
+L 343 277
+L 343 291
+L 193 291
+L 193 277" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 128 235
+L 343 235
+L 343 249
+L 128 249
+L 128 235" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 193 193
+L 343 193
+L 343 207
+L 193 207
+L 193 193" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 343 151
+L 343 151
+L 343 165
+L 343 165
+L 343 151" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 343 109
+L 494 109
+L 494 123
+L 343 123
+L 343 109" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 343 67
+L 558 67
+L 558 81
+L 343 81
+L 343 67" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 343 25
+L 494 25
+L 494 39
+L 343 39
+L 343 25" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 128 336
+L 343 336
+L 343 350
+L 128 350
+L 128 336" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 193 294
+L 343 294
+L 343 308
+L 193 308
+L 193 294" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 343 252
+L 343 252
+L 343 266
+L 343 266
+L 343 252" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 343 210
+L 494 210
+L 494 224
+L 343 224
+L 343 210" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 343 168
+L 558 168
+L 558 182
+L 343 182
+L 343 168" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 343 126
+L 494 126
+L 494 140
+L 343 140
+L 343 126" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 343 84
+L 343 84
+L 343 98
+L 343 98
+L 343 84" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 193 42
+L 343 42
+L 343 56
+L 193 56
+L 193 42" style="stroke:none;fill:rgb(145,204,117)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChartHorizontal/27-stack_series_negative.svg
+++ b/testdata/svg/bar_chart_test/TestBarChartHorizontal/27-stack_series_negative.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><path d="M 41 20
+L 41 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 20
+L 41 20" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 62
+L 41 62" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 104
+L 41 104" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 146
+L 41 146" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 188
+L 41 188" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 230
+L 41 230" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 272
+L 41 272" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 314
+L 41 314" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 36 356
+L 41 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="19" y="46" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">H</text><text x="20" y="88" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">G</text><text x="22" y="130" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="21" y="172" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="20" y="213" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="20" y="255" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="20" y="297" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="20" y="339" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="41" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-15</text><text x="130" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-10</text><text x="220" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-5</text><text x="310" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="399" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">5</text><text x="489" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">10</text><text x="561" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">15</text><path d="M 131 20
+L 131 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 221 20
+L 221 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 311 20
+L 311 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 400 20
+L 400 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 490 20
+L 490 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 580 20
+L 580 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 311 319
+L 311 319
+L 311 351
+L 311 351
+L 311 319" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 311 277
+L 436 277
+L 436 309
+L 311 309
+L 311 277" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 311 235
+L 490 235
+L 490 267
+L 311 267
+L 311 235" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 311 193
+L 436 193
+L 436 225
+L 311 225
+L 311 193" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 311 151
+L 311 151
+L 311 183
+L 311 183
+L 311 151" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 186 109
+L 311 109
+L 311 141
+L 186 141
+L 186 109" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 132 67
+L 311 67
+L 311 99
+L 132 99
+L 132 67" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 186 25
+L 311 25
+L 311 57
+L 186 57
+L 186 25" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 186 319
+L 311 319
+L 311 351
+L 186 351
+L 186 319" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 132 277
+L 311 277
+L 311 309
+L 132 309
+L 132 277" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 186 235
+L 311 235
+L 311 267
+L 186 267
+L 186 235" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 436 193
+L 436 193
+L 436 225
+L 436 225
+L 436 193" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 311 151
+L 436 151
+L 436 183
+L 311 183
+L 311 151" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 311 109
+L 490 109
+L 490 141
+L 311 141
+L 311 109" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 311 67
+L 436 67
+L 436 99
+L 311 99
+L 311 67" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 311 25
+L 311 25
+L 311 57
+L 311 57
+L 311 25" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 311 319
+L 364 319
+L 364 351
+L 311 351
+L 311 319" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 436 277
+L 525 277
+L 525 309
+L 436 309
+L 436 277" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 490 235
+L 543 235
+L 543 267
+L 490 267
+L 490 235" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 436 193
+L 436 193
+L 436 225
+L 436 225
+L 436 193" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 258 151
+L 311 151
+L 311 183
+L 258 183
+L 258 151" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 97 109
+L 186 109
+L 186 141
+L 97 141
+L 97 109" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 79 67
+L 132 67
+L 132 99
+L 79 99
+L 79 67" style="stroke:none;fill:rgb(250,200,88)"/><path d="M 311 25
+L 311 25
+L 311 57
+L 311 57
+L 311 25" style="stroke:none;fill:rgb(250,200,88)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChartHorizontal/28-rounded_caps_negative.svg
+++ b/testdata/svg/bar_chart_test/TestBarChartHorizontal/28-rounded_caps_negative.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><path d="M 40 20
+L 40 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 20
+L 40 20" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 76
+L 40 76" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 132
+L 40 132" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 188
+L 40 188" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 244
+L 40 244" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 300
+L 40 300" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 356
+L 40 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="21" y="53" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="20" y="109" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="19" y="165" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="19" y="220" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="19" y="276" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="19" y="332" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="40" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-10</text><text x="147" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-5</text><text x="255" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="363" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">5</text><text x="471" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">10</text><text x="561" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">15</text><path d="M 148 20
+L 148 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 256 20
+L 256 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 364 20
+L 364 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 472 20
+L 472 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 580 20
+L 580 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 256 310
+L 357 310
+L 357 310
+A 7 7 0 0 1 364 317
+L 364 318
+L 364 318
+A 7 7 0 0 1 357 325
+L 256 325
+L 256 310
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 256 254
+L 465 254
+L 465 254
+A 7 7 0 0 1 472 261
+L 472 262
+L 472 262
+A 7 7 0 0 1 465 269
+L 256 269
+L 256 254
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 256 198
+L 357 198
+L 357 198
+A 7 7 0 0 1 364 205
+L 364 206
+L 364 206
+A 7 7 0 0 1 357 213
+L 256 213
+L 256 198
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 155 142
+L 256 142
+L 256 157
+L 155 157
+L 155 157
+A 7 7 0 0 1 148 150
+L 148 149
+L 148 149
+A 7 7 0 0 1 155 142
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 48 86
+L 256 86
+L 256 101
+L 48 101
+L 48 101
+A 7 7 0 0 1 41 94
+L 41 93
+L 41 93
+A 7 7 0 0 1 48 86
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 155 30
+L 256 30
+L 256 45
+L 155 45
+L 155 45
+A 7 7 0 0 1 148 38
+L 148 37
+L 148 37
+A 7 7 0 0 1 155 30
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 48 330
+L 256 330
+L 256 345
+L 48 345
+L 48 345
+A 7 7 0 0 1 41 338
+L 41 337
+L 41 337
+A 7 7 0 0 1 48 330
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 155 274
+L 256 274
+L 256 289
+L 155 289
+L 155 289
+A 7 7 0 0 1 148 282
+L 148 281
+L 148 281
+A 7 7 0 0 1 155 274
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 256 218
+L 357 218
+L 357 218
+A 7 7 0 0 1 364 225
+L 364 226
+L 364 226
+A 7 7 0 0 1 357 233
+L 256 233
+L 256 218
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 256 162
+L 465 162
+L 465 162
+A 7 7 0 0 1 472 169
+L 472 170
+L 472 170
+A 7 7 0 0 1 465 177
+L 256 177
+L 256 162
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 256 106
+L 357 106
+L 357 106
+A 7 7 0 0 1 364 113
+L 364 114
+L 364 114
+A 7 7 0 0 1 357 121
+L 256 121
+L 256 106
+Z" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 155 50
+L 256 50
+L 256 65
+L 155 65
+L 155 65
+A 7 7 0 0 1 148 58
+L 148 57
+L 148 57
+A 7 7 0 0 1 155 50
+Z" style="stroke:none;fill:rgb(145,204,117)"/></svg>

--- a/testdata/svg/bar_chart_test/TestBarChartHorizontal/29-label_negative.svg
+++ b/testdata/svg/bar_chart_test/TestBarChartHorizontal/29-label_negative.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><path d="M 40 20
+L 40 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 20
+L 40 20" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 76
+L 40 76" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 132
+L 40 132" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 188
+L 40 188" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 244
+L 40 244" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 300
+L 40 300" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 356
+L 40 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="21" y="53" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="20" y="109" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="19" y="165" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="19" y="220" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="19" y="276" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="19" y="332" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="40" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-18</text><text x="147" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-12</text><text x="255" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-6</text><text x="363" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="471" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">6</text><text x="561" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">12</text><path d="M 148 20
+L 148 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 256 20
+L 256 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 364 20
+L 364 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 472 20
+L 472 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 580 20
+L 580 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 364 310
+L 454 310
+L 454 325
+L 364 325
+L 364 310" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 364 254
+L 544 254
+L 544 269
+L 364 269
+L 364 254" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 364 198
+L 454 198
+L 454 213
+L 364 213
+L 364 198" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 274 142
+L 364 142
+L 364 157
+L 274 157
+L 274 142" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 184 86
+L 364 86
+L 364 101
+L 184 101
+L 184 86" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 274 30
+L 364 30
+L 364 45
+L 274 45
+L 274 30" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 184 330
+L 364 330
+L 364 345
+L 184 345
+L 184 330" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 274 274
+L 364 274
+L 364 289
+L 274 289
+L 274 274" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 364 218
+L 454 218
+L 454 233
+L 364 233
+L 364 218" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 364 162
+L 544 162
+L 544 177
+L 364 177
+L 364 162" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 364 106
+L 454 106
+L 454 121
+L 364 121
+L 364 106" style="stroke:none;fill:rgb(145,204,117)"/><path d="M 274 50
+L 364 50
+L 364 65
+L 274 65
+L 274 50" style="stroke:none;fill:rgb(145,204,117)"/><text x="459" y="322" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">5</text><text x="549" y="266" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">10</text><text x="459" y="210" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">5</text><text x="256" y="154" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-5</text><text x="159" y="98" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-10</text><text x="256" y="42" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-5</text><text x="159" y="342" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-10</text><text x="256" y="286" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-5</text><text x="459" y="230" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">5</text><text x="549" y="174" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">10</text><text x="459" y="118" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">5</text><text x="256" y="62" style="stroke:none;fill:rgb(70,70,70);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-5</text></svg>

--- a/testdata/svg/bar_chart_test/TestBarChartHorizontal/30-mark_point_negative.svg
+++ b/testdata/svg/bar_chart_test/TestBarChartHorizontal/30-mark_point_negative.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 400"><path d="M 0 0
+L 600 0
+L 600 400
+L 0 400
+L 0 0" style="stroke:none;fill:white"/><path d="M 40 20
+L 40 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 20
+L 40 20" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 76
+L 40 76" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 132
+L 40 132" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 188
+L 40 188" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 244
+L 40 244" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 300
+L 40 300" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><path d="M 35 356
+L 40 356" style="stroke-width:1;stroke:rgb(110,112,121);fill:none"/><text x="21" y="53" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">F</text><text x="20" y="109" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">E</text><text x="19" y="165" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">D</text><text x="19" y="220" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">C</text><text x="19" y="276" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">B</text><text x="19" y="332" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">A</text><text x="40" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-18</text><text x="147" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-12</text><text x="255" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">-6</text><text x="363" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">0</text><text x="471" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">6</text><text x="561" y="375" style="stroke:none;fill:rgb(70,70,70);font-size:16px;font-family:'Roboto Medium',sans-serif">12</text><path d="M 148 20
+L 148 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 256 20
+L 256 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 364 20
+L 364 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 472 20
+L 472 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 580 20
+L 580 352" style="stroke-width:1;stroke:rgb(224,230,242);fill:none"/><path d="M 364 310
+L 454 310
+L 454 346
+L 364 346
+L 364 310" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 364 254
+L 544 254
+L 544 290
+L 364 290
+L 364 254" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 364 198
+L 454 198
+L 454 234
+L 364 234
+L 364 198" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 274 142
+L 364 142
+L 364 178
+L 274 178
+L 274 142" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 184 86
+L 364 86
+L 364 122
+L 184 122
+L 184 86" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 274 30
+L 364 30
+L 364 66
+L 274 66
+L 274 30" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 176.52 107.62
+A 14 14 0 1 1 176.52 100.38
+L 163 104
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 163 118
+Q198,104 163,90
+Z" style="stroke:none;fill:rgb(84,112,198)"/><text x="151" y="109" style="stroke:none;fill:rgb(238,238,238);font-size:13.3px;font-family:'Roboto Medium',sans-serif">-10</text><path d="M 551.48 268.38
+A 14 14 0 1 1 551.48 275.62
+L 565 272
+Z" style="stroke:none;fill:rgb(84,112,198)"/><path d="M 565 258
+Q530,272 565,286
+Z" style="stroke:none;fill:rgb(84,112,198)"/><text x="561" y="277" style="stroke:none;fill:rgb(238,238,238);font-size:13.3px;font-family:'Roboto Medium',sans-serif">10</text></svg>


### PR DESCRIPTION
Bars now extend below zero for negative data. Axis ranges spanning zero are aligned so zero lands on a label grid tick. Mark point pins rotate to face away from the bar tip, and series labels flip position for negative bars.

Basic Stacked Series Examples:
<img width="600" height="400" alt="TestBarChart 30-stack_series_negative-actual-3614918732" src="https://github.com/user-attachments/assets/c2a79f03-3824-48bd-8502-d5b69a725cf9" />
<img width="600" height="400" alt="TestBarChartHorizontal 27-stack_series_negative-actual-2702603684" src="https://github.com/user-attachments/assets/3b16aa1d-fe7c-468b-8c05-ad2241f16a8b" />

Fixes #134 